### PR TITLE
fix(jwt): fix parseSSHPublicKey method to read RS384 keys

### DIFF
--- a/src/main/java/io/gravitee/policy/jwt/key/PublicKeyHelper.java
+++ b/src/main/java/io/gravitee/policy/jwt/key/PublicKeyHelper.java
@@ -18,6 +18,7 @@ package io.gravitee.policy.jwt.key;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.math.BigInteger;
+import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.security.KeyFactory;
 import java.security.interfaces.RSAPublicKey;
@@ -36,7 +37,7 @@ public final class PublicKeyHelper {
     private static final Pattern SSH_PUB_KEY = Pattern.compile("(ssh-(rsa|dsa) )?([A-Za-z0-9/+]+=*) ?(.*)");
 
     private static final byte[] PREFIX = new byte[] {0,0,0,7, 's','s','h','-','r','s','a'};
-    
+
     private static final String SSH_RSA_ALG = "ssh-rsa";
 
     /**
@@ -112,7 +113,7 @@ public final class PublicKeyHelper {
             throw new IOException("Expected length data as 4 bytes");
         }
 
-        int l = (b[0] << 24) | (b[1] << 16) | (b[2] << 8) | b[3];
+        int l = ByteBuffer.wrap(b).getInt();
 
         b = new byte[l];
 

--- a/src/test/java/io/gravitee/policy/jwt/key/PublicKeyHelperTest.java
+++ b/src/test/java/io/gravitee/policy/jwt/key/PublicKeyHelperTest.java
@@ -46,4 +46,11 @@ public class PublicKeyHelperTest {
 
         Assert.assertNotNull(publicKey);
     }
+
+    @Test
+    public void shouldGetPublicKey_completeSshRsa_RS384() {
+        RSAPublicKey publicKey = PublicKeyHelper.parsePublicKey("ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCBKYIaYRQU5eHRNqi09OP/dxY/uqS3+RYUBDMBaQeaCydgxciGWg0ijY+FlkjaIj/dlC4QfNxsglOgZtlZ2oFiQ5sDri0kGcczRbgDkTpg0q9+2W0huFxccCM0YOGuKBN8VZCIQhnRvC4gPHwzOdgNNCJqJc0qbuwN9WEkBt5O5aqLbVS395r9qbHFg76K3TVbPUXLtYr6Cmig9iTePEBiXyS4ZV0JjqvDryNP/nCeWf9oz091Eto3UKPZ4K6h1fsi7F9OdP867/2I+F3y/Gxdwk4GHkpq/mVzzVM3x//xTPYfgTZtDf8triNS3gBn0JbEIk8sSMh5MVA1nnAoEsxQM6WWlYJbLbWT5Q1N5nQKShTTnAamTuUg2o4MPJoozVW7GDYHWLL6zkbwGzjXULeZQVQi0VH7ZXdXjk4FC6DxmrIRE9gZhkFC7YpMk/fUmB7aLsXGkpLxjM/2DEq02ypAFfPcQwR3Oi0S+TKb9DqwjX/sb06C4n7pIaZzxMJn4xc= brasseld@gmail.com");
+
+        Assert.assertNotNull(publicKey);
+    }
 }


### PR DESCRIPTION
fixes gravitee-io/issues#2147