### PR TITLE
feat: use expression-language component in studio-policy form

### DIFF
--- a/src/main/resources/schemas/schema-form.json
+++ b/src/main/resources/schemas/schema-form.json
@@ -58,7 +58,8 @@
           "lineNumbers": true,
           "allowDropFileTypes": true,
           "autoCloseTags": true
-        }
+        },
+        "expression-language": true
       }
     },
     "useSystemProxy" : {


### PR DESCRIPTION
fix: gravitee-io/issues#60