### PR TITLE
refactor: use common vertx proxy options factory

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -19,6 +19,18 @@ Some authorization servers use OAuth2 protocol to provide access tokens. These a
 
 - JWT (JSON Web Token) standard RFC: (https://tools.ietf.org/html/rfc7519
 
+
+== Compatibility with APIM
+
+|===
+|Plugin version | APIM version
+
+|2.x and upper                  | 3.18.x to latest
+|1.22.x and upper               | 3.15.x to 3.17.x
+|1.20.x to 1.21.x               | 3.10.x to 3.14.x
+|Up to 1.19.x                   | Up to 3.9.x
+|===
+
 === JWT
 
 A JWT is composed of three parts: a header, a payload and a signature.

--- a/pom.xml
+++ b/pom.xml
@@ -35,9 +35,10 @@
 
     <properties>
         <gravitee-bom.version>1.1</gravitee-bom.version>
+        <gravitee-common.version>1.26.1</gravitee-common.version>
+        <gravitee-node.version>1.23.0</gravitee-node.version>
         <gravitee-gateway-api.version>1.31.0</gravitee-gateway-api.version>
         <gravitee-policy-api.version>1.6.0</gravitee-policy-api.version>
-        <gravitee-common.version>1.15.5</gravitee-common.version>
         <nimbus-jose-jwt.version>6.3</nimbus-jose-jwt.version>
         <guava.version>26.0-jre</guava.version>
         <json-schema-generator-maven-plugin.version>1.1.0</json-schema-generator-maven-plugin.version>
@@ -81,6 +82,20 @@
             <groupId>io.gravitee.common</groupId>
             <artifactId>gravitee-common</artifactId>
             <version>${gravitee-common.version}</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.gravitee.node</groupId>
+            <artifactId>gravitee-node-api</artifactId>
+            <version>${gravitee-node.version}</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.gravitee.node</groupId>
+            <artifactId>gravitee-node-container</artifactId>
+            <version>${gravitee-node.version}</version>
             <scope>provided</scope>
         </dependency>
 


### PR DESCRIPTION
see https://github.com/gravitee-io/issues/issues/7739
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `2.0.0-refactor-use-commong-proxy-options-factory-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/policy/gravitee-policy-jwt/2.0.0-refactor-use-commong-proxy-options-factory-SNAPSHOT/gravitee-policy-jwt-2.0.0-refactor-use-commong-proxy-options-factory-SNAPSHOT.zip)
  <!-- Version placeholder end -->
