### PR TITLE
update security policy to be compatible with async reactor

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -16,13 +16,13 @@
     limitations under the License.
 
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>io.gravitee.policy</groupId>
     <artifactId>gravitee-policy-jwt</artifactId>
-    <version>2.1.1</version>
+    <version>2.2.0-8238-entrypoint-SNAPSHOT</version>
 
     <name>Gravitee.io APIM - Policy - JWT</name>
     <description>Description of the JWT Gravitee Policy</description>
@@ -34,11 +34,12 @@
     </parent>
 
     <properties>
-        <gravitee-bom.version>2.5</gravitee-bom.version>
-        <gravitee-gateway-api.version>1.33.0</gravitee-gateway-api.version>
+        <gravitee-bom.version>2.6</gravitee-bom.version>
+        <gravitee-gateway-api.version>1.38.0</gravitee-gateway-api.version>
         <gravitee-policy-api.version>1.11.0</gravitee-policy-api.version>
         <gravitee-common.version>1.27.0</gravitee-common.version>
-        <gravitee-node.version>1.23.0</gravitee-node.version>
+        <gravitee-node.version>1.24.1</gravitee-node.version>
+        <gravitee-expression-language.version>1.10.1</gravitee-expression-language.version>
         <nimbus-jose-jwt.version>9.15.2</nimbus-jose-jwt.version>
         <guava.version>26.0-jre</guava.version>
         <json-schema-generator-maven-plugin.version>1.1.0</json-schema-generator-maven-plugin.version>
@@ -66,6 +67,16 @@
                 <artifactId>gravitee-common</artifactId>
                 <version>${gravitee-common.version}</version>
             </dependency>
+            <dependency>
+                <groupId>io.gravitee.node</groupId>
+                <artifactId>gravitee-node-api</artifactId>
+                <version>${gravitee-node.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.gravitee.gateway</groupId>
+                <artifactId>gravitee-gateway-api</artifactId>
+                <version>${gravitee-gateway-api.version}</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 
@@ -74,7 +85,13 @@
         <dependency>
             <groupId>io.gravitee.gateway</groupId>
             <artifactId>gravitee-gateway-api</artifactId>
-            <version>${gravitee-gateway-api.version}</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.gravitee.el</groupId>
+            <artifactId>gravitee-expression-language</artifactId>
+            <version>${gravitee-expression-language.version}</version>
             <scope>provided</scope>
         </dependency>
 
@@ -88,14 +105,12 @@
         <dependency>
             <groupId>io.gravitee.common</groupId>
             <artifactId>gravitee-common</artifactId>
-            <version>${gravitee-common.version}</version>
             <scope>provided</scope>
         </dependency>
 
         <dependency>
             <groupId>io.gravitee.node</groupId>
             <artifactId>gravitee-node-api</artifactId>
-            <version>${gravitee-node.version}</version>
             <scope>provided</scope>
         </dependency>
 
@@ -184,7 +199,6 @@
             <version>${wiremock.version}</version>
             <scope>test</scope>
         </dependency>
-
     </dependencies>
 
     <build>
@@ -246,9 +260,9 @@
             <plugin>
                 <groupId>com.hubspot.maven.plugins</groupId>
                 <artifactId>prettier-maven-plugin</artifactId>
-                <version>0.17</version>
+                <version>0.18</version>
                 <configuration>
-                    <nodeVersion>12.13.0</nodeVersion>
+                    <nodeVersion>16.16.0</nodeVersion>
                     <prettierJavaVersion>1.6.1</prettierJavaVersion>
                 </configuration>
                 <executions>

--- a/src/main/java/io/gravitee/policy/jwt/jwk/provider/DefaultJWTProcessorProvider.java
+++ b/src/main/java/io/gravitee/policy/jwt/jwk/provider/DefaultJWTProcessorProvider.java
@@ -18,6 +18,7 @@ package io.gravitee.policy.jwt.jwk.provider;
 import com.nimbusds.jose.proc.SecurityContext;
 import com.nimbusds.jwt.proc.JWTProcessor;
 import io.gravitee.gateway.jupiter.api.context.ExecutionContext;
+import io.gravitee.gateway.jupiter.api.context.HttpExecutionContext;
 import io.gravitee.gateway.jupiter.api.context.RequestExecutionContext;
 import io.gravitee.policy.jwt.configuration.JWTPolicyConfiguration;
 import io.gravitee.policy.v3.jwt.resolver.KeyResolver;
@@ -47,7 +48,7 @@ public class DefaultJWTProcessorProvider implements JWTProcessorProvider {
     }
 
     @Override
-    public Maybe<JWTProcessor<SecurityContext>> provide(RequestExecutionContext ctx) {
+    public Maybe<JWTProcessor<SecurityContext>> provide(HttpExecutionContext ctx) {
         if (jwtProcessorProvider == null) {
             return Maybe.empty();
         }

--- a/src/main/java/io/gravitee/policy/jwt/jwk/provider/GatewayKeysJWTProcessorProvider.java
+++ b/src/main/java/io/gravitee/policy/jwt/jwk/provider/GatewayKeysJWTProcessorProvider.java
@@ -26,6 +26,7 @@ import com.nimbusds.jose.proc.SecurityContext;
 import com.nimbusds.jwt.proc.DefaultJWTProcessor;
 import com.nimbusds.jwt.proc.JWTProcessor;
 import io.gravitee.common.util.EnvironmentUtils;
+import io.gravitee.gateway.jupiter.api.context.HttpExecutionContext;
 import io.gravitee.gateway.jupiter.api.context.RequestExecutionContext;
 import io.gravitee.policy.jwt.configuration.JWTPolicyConfiguration;
 import io.gravitee.policy.jwt.jwk.selector.IssuerAwareJWSKeySelector;
@@ -51,10 +52,9 @@ import org.springframework.core.env.ConfigurableEnvironment;
  */
 class GatewayKeysJWTProcessorProvider implements JWTProcessorProvider {
 
-    private static final Logger log = LoggerFactory.getLogger(GatewayKeysJWTProcessorProvider.class);
-
-    private static final String DEFAULT_KID = "default";
     protected static final String KEY_PROPERTY_PREFIX = "policy.jwt.issuer";
+    private static final Logger log = LoggerFactory.getLogger(GatewayKeysJWTProcessorProvider.class);
+    private static final String DEFAULT_KID = "default";
     private static final Pattern KEY_PROPERTY_PATTERN = Pattern.compile("^policy\\.jwt\\.issuer\\.(?<iss>.*)\\.(?<kid>.*)$");
 
     private final JWTPolicyConfiguration configuration;
@@ -68,11 +68,11 @@ class GatewayKeysJWTProcessorProvider implements JWTProcessorProvider {
      * Creates the {@link JWTProcessor} with all the keys defined at gateway level and cache it for reuse.
      */
     @Override
-    public Maybe<JWTProcessor<SecurityContext>> provide(RequestExecutionContext ctx) {
+    public Maybe<JWTProcessor<SecurityContext>> provide(HttpExecutionContext ctx) {
         return Maybe.fromCallable(() -> buildJWTProcessor(ctx));
     }
 
-    private JWTProcessor<SecurityContext> buildJWTProcessor(RequestExecutionContext ctx) {
+    private JWTProcessor<SecurityContext> buildJWTProcessor(HttpExecutionContext ctx) {
         final JWSAlgorithm alg = configuration.getSignature().getAlg();
         final Map<String, List<JWK>> jwkByIssuer = loadFromConfiguration(alg, ctx.getComponent(ConfigurableEnvironment.class));
         final Map<String, JWSKeySelector<SecurityContext>> selectors = createJWSKeySelectors(alg, jwkByIssuer);

--- a/src/main/java/io/gravitee/policy/jwt/jwk/provider/GivenKeyJWTProcessorProvider.java
+++ b/src/main/java/io/gravitee/policy/jwt/jwk/provider/GivenKeyJWTProcessorProvider.java
@@ -23,6 +23,7 @@ import com.nimbusds.jose.proc.JWSKeySelector;
 import com.nimbusds.jose.proc.SecurityContext;
 import com.nimbusds.jwt.proc.DefaultJWTProcessor;
 import com.nimbusds.jwt.proc.JWTProcessor;
+import io.gravitee.gateway.jupiter.api.context.HttpExecutionContext;
 import io.gravitee.gateway.jupiter.api.context.RequestExecutionContext;
 import io.gravitee.policy.jwt.configuration.JWTPolicyConfiguration;
 import io.gravitee.policy.jwt.jwk.selector.NoKidJWSVerificationKeySelector;
@@ -53,7 +54,7 @@ class GivenKeyJWTProcessorProvider implements JWTProcessorProvider {
      * Creates the {@link JWTProcessor} with the given key defined at the policy configuration level and cache it for reuse.
      */
     @Override
-    public Maybe<JWTProcessor<SecurityContext>> provide(RequestExecutionContext ctx) {
+    public Maybe<JWTProcessor<SecurityContext>> provide(HttpExecutionContext ctx) {
         return Maybe.fromCallable(() -> buildJWTProcessor(ctx.getInternalAttribute(RESOLVED_PARAMETER)));
     }
 

--- a/src/main/java/io/gravitee/policy/jwt/jwk/provider/JWTProcessorProvider.java
+++ b/src/main/java/io/gravitee/policy/jwt/jwk/provider/JWTProcessorProvider.java
@@ -17,6 +17,7 @@ package io.gravitee.policy.jwt.jwk.provider;
 
 import com.nimbusds.jose.proc.SecurityContext;
 import com.nimbusds.jwt.proc.JWTProcessor;
+import io.gravitee.gateway.jupiter.api.context.HttpExecutionContext;
 import io.gravitee.gateway.jupiter.api.context.RequestExecutionContext;
 import io.reactivex.Maybe;
 
@@ -34,5 +35,5 @@ public interface JWTProcessorProvider {
      * @param ctx the current execution context.
      * @return a {@link Maybe} containing an {@link JWTProcessor}.
      */
-    Maybe<JWTProcessor<SecurityContext>> provide(RequestExecutionContext ctx);
+    Maybe<JWTProcessor<SecurityContext>> provide(final HttpExecutionContext ctx);
 }

--- a/src/main/java/io/gravitee/policy/jwt/jwk/provider/JwksUrlJWTProcessorProvider.java
+++ b/src/main/java/io/gravitee/policy/jwt/jwk/provider/JwksUrlJWTProcessorProvider.java
@@ -22,6 +22,7 @@ import com.nimbusds.jose.proc.JWSVerificationKeySelector;
 import com.nimbusds.jose.proc.SecurityContext;
 import com.nimbusds.jwt.proc.DefaultJWTProcessor;
 import com.nimbusds.jwt.proc.JWTProcessor;
+import io.gravitee.gateway.jupiter.api.context.HttpExecutionContext;
 import io.gravitee.gateway.jupiter.api.context.RequestExecutionContext;
 import io.gravitee.node.api.configuration.Configuration;
 import io.gravitee.policy.jwt.configuration.JWTPolicyConfiguration;
@@ -58,11 +59,11 @@ class JwksUrlJWTProcessorProvider implements JWTProcessorProvider {
      * @see JWKSUrlJWKSourceResolver
      */
     @Override
-    public Maybe<JWTProcessor<SecurityContext>> provide(RequestExecutionContext ctx) {
+    public Maybe<JWTProcessor<SecurityContext>> provide(HttpExecutionContext ctx) {
         return Maybe.defer(() -> buildJWTProcessor(ctx, ctx.getInternalAttribute(RESOLVED_PARAMETER)));
     }
 
-    private Maybe<JWTProcessor<SecurityContext>> buildJWTProcessor(RequestExecutionContext ctx, String url) {
+    private Maybe<JWTProcessor<SecurityContext>> buildJWTProcessor(HttpExecutionContext ctx, String url) {
         // Create a source resolver to resolve the Json Web Keystore from an url.
         final JWKSUrlJWKSourceResolver<SecurityContext> sourceResolver = new JWKSUrlJWKSourceResolver<>(
             url,
@@ -84,7 +85,7 @@ class JwksUrlJWTProcessorProvider implements JWTProcessorProvider {
         return sourceResolver.initialize().andThen(Maybe.just(jwtProcessor));
     }
 
-    private ResourceRetriever getResourceRetriever(RequestExecutionContext ctx) {
+    private ResourceRetriever getResourceRetriever(HttpExecutionContext ctx) {
         if (resourceRetriever == null) {
             resourceRetriever =
                 new VertxResourceRetriever(

--- a/src/main/java/io/gravitee/policy/jwt/utils/TokenExtractor.java
+++ b/src/main/java/io/gravitee/policy/jwt/utils/TokenExtractor.java
@@ -18,6 +18,7 @@ package io.gravitee.policy.jwt.utils;
 import io.gravitee.common.util.MultiValueMap;
 import io.gravitee.gateway.api.http.HttpHeaderNames;
 import io.gravitee.gateway.api.http.HttpHeaders;
+import io.gravitee.gateway.jupiter.api.context.HttpRequest;
 import io.gravitee.gateway.jupiter.api.context.Request;
 import java.util.List;
 import java.util.Optional;
@@ -47,20 +48,20 @@ public class TokenExtractor {
      *
      * @return the jwt token as string, {@link Optional#empty()} if no token has been found.
      * @throws AuthorizationSchemeException in case of malformed Authorization bearer or not supported Authorization scheme.
-     * @see #lookFor(Request)
+     * @see #lookFor(HttpRequest)
      */
-    public static Optional<String> extract(Request request) throws AuthorizationSchemeException {
+    public static Optional<String> extract(HttpRequest request) throws AuthorizationSchemeException {
         return extractFromHeaders(request.headers()).or(() -> extractFromParameters(request.parameters()));
     }
 
     /**
-     * Same as {@link #extract(Request)} but silently capture potential {@link AuthorizationSchemeException} and return empty instead.
+     * Same as {@link #extract(HttpRequest)} but silently capture potential {@link AuthorizationSchemeException} and return empty instead.
      *
      * @param request the request to extract the JWT token from.
      *
      * @return the jwt token as string, {@link Optional#empty()} if no token has been found or is malformed.
      */
-    public static Optional<String> lookFor(Request request) {
+    public static Optional<String> lookFor(HttpRequest request) {
         try {
             return extract(request);
         } catch (AuthorizationSchemeException e) {
@@ -107,7 +108,7 @@ public class TokenExtractor {
      *
      * @param request the request to extract the JWT token from.
      * @return the jwt token as string or <code>null</code> if no token has been found.
-     * @see #extract(Request)
+     * @see #extract(HttpRequest)
      */
     @Deprecated
     public static String extract(io.gravitee.gateway.api.Request request) throws AuthorizationSchemeException {


### PR DESCRIPTION


**Issue**

https://github.com/gravitee-io/issues/issues/8009

**Description**

Update policy to handle new message execution context
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `2.2.0-8238-entrypoint-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/policy/gravitee-policy-jwt/2.2.0-8238-entrypoint-SNAPSHOT/gravitee-policy-jwt-2.2.0-8238-entrypoint-SNAPSHOT.zip)
  <!-- Version placeholder end -->
