### PR TITLE
test: fix V3 integration tests following gateway plan selection changes

### DIFF
--- a/src/test/java/io/gravitee/policy/v3/jwt/JwtPolicyV3IntegrationTest.java
+++ b/src/test/java/io/gravitee/policy/v3/jwt/JwtPolicyV3IntegrationTest.java
@@ -52,7 +52,8 @@ public class JwtPolicyV3IntegrationTest extends JwtPolicyIntegrationTest {
      */
     @Override
     protected OngoingStubbing<Optional<Subscription>> whenSearchingSubscription(String api, String clientId, String plan) {
-        return when(getBean(SubscriptionService.class).getByApiAndClientIdAndPlan(api, clientId, plan));
+        // FIXME: Use plan instead of `null` to properly handle plan selection in multi-plan context
+        return when(getBean(SubscriptionService.class).getByApiAndClientIdAndPlan(api, clientId, null));
     }
 
     /**


### PR DESCRIPTION
V3 Integration tests were broken since gateway plan selection changes
From this commit : https://github.com/gravitee-io/gravitee-api-management/commit/5fde6825ea056c653e5f2f0913939265b34f6a3a#diff-058113210dd388c38063cc57b6a4575d1145f8004a804864955f08094c59681aR57