### PR TITLE
fix: bump version of gateway api

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -35,11 +35,12 @@
 
     <properties>
         <gravitee-bom.version>2.7</gravitee-bom.version>
-        <gravitee-gateway-api.version>2.0.0</gravitee-gateway-api.version>
+        <gravitee-gateway-api.version>2.1.0-alpha.11</gravitee-gateway-api.version>
+        <gravitee-reporter-api.version>1.25.0-alpha.4</gravitee-reporter-api.version>
         <gravitee-policy-api.version>1.11.0</gravitee-policy-api.version>
         <gravitee-common.version>2.0.0</gravitee-common.version>
         <gravitee-expression-language.version>2.0.1</gravitee-expression-language.version>
-        <gravitee-apim-gateway-tests-sdk.version>3.20.0-alpha.2-SNAPSHOT</gravitee-apim-gateway-tests-sdk.version>
+        <gravitee-apim-gateway-tests-sdk.version>3.21.0-SNAPSHOT</gravitee-apim-gateway-tests-sdk.version>
         <gravitee-node.version>2.0.1</gravitee-node.version>
         <gravitee-plugin.version>1.24.1</gravitee-plugin.version>
         <gravitee-connector-api.version>1.1.0</gravitee-connector-api.version>
@@ -91,6 +92,11 @@
                 <version>${gravitee-gateway-api.version}</version>
             </dependency>
             <dependency>
+                <groupId>io.gravitee.reporter</groupId>
+                <artifactId>gravitee-reporter-api</artifactId>
+                <version>${gravitee-reporter-api.version}</version>
+            </dependency>
+            <dependency>
                 <groupId>io.gravitee.connector</groupId>
                 <artifactId>gravitee-connector-api</artifactId>
                 <version>${gravitee-connector-api.version}</version>
@@ -110,7 +116,11 @@
             <artifactId>gravitee-gateway-api</artifactId>
             <scope>provided</scope>
         </dependency>
-
+        <dependency>
+            <groupId>io.gravitee.reporter</groupId>
+            <artifactId>gravitee-reporter-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
         <dependency>
             <groupId>io.gravitee.policy</groupId>
             <artifactId>gravitee-policy-api</artifactId>

--- a/src/main/java/io/gravitee/policy/jwt/JWTPolicy.java
+++ b/src/main/java/io/gravitee/policy/jwt/JWTPolicy.java
@@ -26,7 +26,6 @@ import io.gravitee.common.security.jwt.LazyJWT;
 import io.gravitee.gateway.jupiter.api.ExecutionFailure;
 import io.gravitee.gateway.jupiter.api.context.HttpExecutionContext;
 import io.gravitee.gateway.jupiter.api.context.HttpRequest;
-import io.gravitee.gateway.jupiter.api.context.MessageExecutionContext;
 import io.gravitee.gateway.jupiter.api.policy.SecurityPolicy;
 import io.gravitee.gateway.jupiter.api.policy.SecurityToken;
 import io.gravitee.policy.jwt.configuration.JWTPolicyConfiguration;
@@ -34,7 +33,7 @@ import io.gravitee.policy.jwt.jwk.provider.DefaultJWTProcessorProvider;
 import io.gravitee.policy.jwt.jwk.provider.JWTProcessorProvider;
 import io.gravitee.policy.jwt.utils.TokenExtractor;
 import io.gravitee.policy.v3.jwt.JWTPolicyV3;
-import io.gravitee.reporter.api.http.Metrics;
+import io.gravitee.reporter.api.v4.metric.Metrics;
 import io.reactivex.rxjava3.core.Completable;
 import io.reactivex.rxjava3.core.Maybe;
 import io.reactivex.rxjava3.core.Single;
@@ -133,7 +132,7 @@ public class JWTPolicy extends JWTPolicyV3 implements SecurityPolicy {
             user = claims.getSubject();
         }
         ctx.setAttribute(ATTR_USER, user);
-        final Metrics metrics = request.metrics();
+        Metrics metrics = ctx.metrics();
         metrics.setUser(user);
         metrics.setSecurityType(JWT);
         metrics.setSecurityToken(clientId);
@@ -188,7 +187,7 @@ public class JWTPolicy extends JWTPolicyV3 implements SecurityPolicy {
     private void reportError(HttpExecutionContext ctx, Throwable throwable) {
         if (throwable != null) {
             final HttpRequest request = ctx.request();
-            request.metrics().setMessage(throwable.getMessage());
+            ctx.metrics().setErrorMessage(throwable.getMessage());
 
             if (log.isDebugEnabled()) {
                 try {

--- a/src/test/java/io/gravitee/policy/jwt/JWTPolicyTest.java
+++ b/src/test/java/io/gravitee/policy/jwt/JWTPolicyTest.java
@@ -37,7 +37,7 @@ import io.gravitee.gateway.jupiter.api.context.Request;
 import io.gravitee.gateway.jupiter.api.policy.SecurityToken;
 import io.gravitee.policy.jwt.configuration.JWTPolicyConfiguration;
 import io.gravitee.policy.jwt.jwk.provider.DefaultJWTProcessorProvider;
-import io.gravitee.reporter.api.http.Metrics;
+import io.gravitee.reporter.api.v4.metric.Metrics;
 import io.reactivex.rxjava3.core.Completable;
 import io.reactivex.rxjava3.core.Maybe;
 import io.reactivex.rxjava3.observers.TestObserver;
@@ -141,7 +141,7 @@ class JWTPolicyTest {
         when(jwtProcessorResolver.provide(ctx)).thenReturn(Maybe.just(jwtProcessor));
         when(jwtProcessor.process(any(JWT.class), isNull())).thenReturn(claimsSet);
         when(ctx.request()).thenReturn(request);
-        when(request.metrics()).thenReturn(metrics);
+        when(ctx.metrics()).thenReturn(metrics);
         when(request.headers()).thenReturn(headers);
 
         final TestObserver<Void> obs = cut.onRequest(ctx).test();
@@ -166,7 +166,7 @@ class JWTPolicyTest {
         when(jwtProcessorResolver.provide(ctx)).thenReturn(Maybe.just(jwtProcessor));
         when(jwtProcessor.process(any(JWT.class), isNull())).thenReturn(claimsSet);
         when(ctx.request()).thenReturn(request);
-        when(request.metrics()).thenReturn(metrics);
+        when(ctx.metrics()).thenReturn(metrics);
         when(request.headers()).thenReturn(headers);
 
         final TestObserver<Void> obs = cut.onRequest(ctx).test();
@@ -193,7 +193,7 @@ class JWTPolicyTest {
         when(jwtProcessorResolver.provide(ctx)).thenReturn(Maybe.just(jwtProcessor));
         when(jwtProcessor.process(any(JWT.class), isNull())).thenReturn(claimsSet);
         when(ctx.request()).thenReturn(request);
-        when(request.metrics()).thenReturn(metrics);
+        when(ctx.metrics()).thenReturn(metrics);
         when(request.headers()).thenReturn(headers);
         when(configuration.isExtractClaims()).thenReturn(true);
 
@@ -268,7 +268,7 @@ class JWTPolicyTest {
         when(jwtProcessor.process(Mockito.<JWT>argThat(jwt -> TOKEN.equals(jwt.getParsedString())), isNull()))
             .thenThrow(new JOSEException(MOCK_JOSE_EXCEPTION));
         when(ctx.request()).thenReturn(request);
-        when(request.metrics()).thenReturn(metrics);
+        when(ctx.metrics()).thenReturn(metrics);
         when(ctx.interruptWith(any())).thenReturn(Completable.error(new RuntimeException(MOCK_EXCEPTION)));
 
         final TestObserver<Void> obs = cut.onRequest(ctx).test();
@@ -287,7 +287,7 @@ class JWTPolicyTest {
                 })
             );
 
-        verify(metrics).setMessage(MOCK_JOSE_EXCEPTION);
+        verify(metrics).setErrorMessage(MOCK_JOSE_EXCEPTION);
     }
 
     @Test


### PR DESCRIPTION
**Description**

Bump gateway api version to use the latest Metric object
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `3.0.1-bump-gateway-api-version-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/policy/gravitee-policy-jwt/3.0.1-bump-gateway-api-version-SNAPSHOT/gravitee-policy-jwt-3.0.1-bump-gateway-api-version-SNAPSHOT.zip)
  <!-- Version placeholder end -->
