### PR TITLE
fix: simplify unauthorized message

### DIFF
--- a/src/test/java/io/gravitee/policy/v3/jwt/JwtPolicyV3IntegrationTest.java
+++ b/src/test/java/io/gravitee/policy/v3/jwt/JwtPolicyV3IntegrationTest.java
@@ -41,17 +41,6 @@ public class JwtPolicyV3IntegrationTest extends JwtPolicyV4EmulationEngineIntegr
      */
     @Override
     protected OngoingStubbing<Optional<Subscription>> whenSearchingSubscription(String api, String clientId, String plan) {
-        // FIXME: Use plan instead of `null` to properly handle plan selection in multi-plan context
-        return when(getBean(SubscriptionService.class).getByApiAndClientIdAndPlan(api, clientId, null));
-    }
-
-    /**
-     * This overrides 401 response HTTP body content assertion :
-     * - in jupiter, it's "Unauthorized"
-     * - in V3, it's sometimes "Unauthorized", sometimes "access_denied"
-     */
-    @Override
-    protected void assertUnauthorizedResponseBody(String responseBody) {
-        assertThat(responseBody).isIn("Unauthorized", "access_denied");
+        return when(getBean(SubscriptionService.class).getByApiAndClientIdAndPlan(api, clientId, plan));
     }
 }


### PR DESCRIPTION
**Description**

  - to avoid giving too much information, all error will only return Unauthorized as message.


**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `4.0.0-simplify-error-message-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/policy/gravitee-policy-jwt/4.0.0-simplify-error-message-SNAPSHOT/gravitee-policy-jwt-4.0.0-simplify-error-message-SNAPSHOT.zip)
  <!-- Version placeholder end -->
