### PR TITLE
fix(deps): update bcprov-jdk15on to bcprov-jdk18on 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -106,15 +106,15 @@
 
         <dependency>
             <groupId>org.bouncycastle</groupId>
-            <artifactId>bcprov-jdk15on</artifactId>
-            <version>[1.52,)</version>
+            <artifactId>bcprov-jdk18on</artifactId>
+            <version>[1.77,)</version>
             <!-- GW already provides this dependency -->
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.bouncycastle</groupId>
-            <artifactId>bcpkix-jdk15on</artifactId>
-            <version>[1.52,)</version>
+            <artifactId>bcpkix-jdk18on</artifactId>
+            <version>[1.77,)</version>
             <!-- GW already provides this dependency -->
             <scope>provided</scope>
         </dependency>


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/APIM-4028

**Description**

The library https://mvnrepository.com/artifact/org.bouncycastle/bcprov-jdk15on has been moved to https://mvnrepository.com/artifact/org.bouncycastle/bcprov-jdk18on
The library https://mvnrepository.com/artifact/org.bouncycastle/bcpkix-jdk15on has been moved to
https://mvnrepository.com/artifact/org.bouncycastle/bcpkix-jdk18on

**Additional context**

The main goal of this task is to update the library and resolve vulnerability issues:
https://security.snyk.io/vuln/SNYK-JAVA-ORGBOUNCYCASTLE-6084022
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `4.1.2-apim-4028-update-to-bcprov-jdk18on-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/policy/gravitee-policy-jwt/4.1.2-apim-4028-update-to-bcprov-jdk18on-SNAPSHOT/gravitee-policy-jwt-4.1.2-apim-4028-update-to-bcprov-jdk18on-SNAPSHOT.zip)
  <!-- Version placeholder end -->
