### PR TITLE
Revert do not use 4.1.4 with version lower or equal to 4.3.x => 4.1.x

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -30,17 +30,16 @@
     <parent>
         <groupId>io.gravitee</groupId>
         <artifactId>gravitee-parent</artifactId>
-        <version>22.1.0</version>
+        <version>22.0.2</version>
     </parent>
 
     <properties>
-        <gravitee-bom.version>7.0.23</gravitee-bom.version>
-        <gravitee-common.version>4.4.0</gravitee-common.version>
-        <gravitee-gateway-api.version>3.5.0</gravitee-gateway-api.version>
-        <gravitee-node.version>5.18.3</gravitee-node.version>
-        <gravitee-apim.version>4.4.0</gravitee-apim.version>
-
+        <gravitee-bom.version>6.0.3</gravitee-bom.version>
+        <gravitee-gateway-api.version>3.0.0</gravitee-gateway-api.version>
         <gravitee-policy-api.version>1.11.0</gravitee-policy-api.version>
+        <gravitee-node.version>3.1.0</gravitee-node.version>
+        <gravitee-common.version>3.3.3</gravitee-common.version>
+        <gravitee-apim.version>4.1.0-SNAPSHOT</gravitee-apim.version>
 
         <nimbus-jose-jwt.version>9.15.2</nimbus-jose-jwt.version>
         <sshj.version>0.35.0</sshj.version>
@@ -78,13 +77,6 @@
                 <artifactId>gravitee-common</artifactId>
                 <version>${gravitee-common.version}</version>
             </dependency>
-            <dependency>
-                <groupId>io.gravitee.node</groupId>
-                <artifactId>gravitee-node</artifactId>
-                <version>${gravitee-node.version}</version>
-                <scope>import</scope>
-                <type>pom</type>
-            </dependency>
         </dependencies>
     </dependencyManagement>
 
@@ -103,16 +95,6 @@
         <dependency>
             <groupId>io.gravitee.common</groupId>
             <artifactId>gravitee-common</artifactId>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>io.gravitee.node</groupId>
-            <artifactId>gravitee-node-api</artifactId>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>io.gravitee.node</groupId>
-            <artifactId>gravitee-node-vertx</artifactId>
             <scope>provided</scope>
         </dependency>
 

--- a/src/main/java/io/gravitee/policy/jwt/jwk/source/VertxResourceRetriever.java
+++ b/src/main/java/io/gravitee/policy/jwt/jwk/source/VertxResourceRetriever.java
@@ -16,8 +16,8 @@
 package io.gravitee.policy.jwt.jwk.source;
 
 import com.nimbusds.jose.util.Resource;
+import io.gravitee.common.util.VertxProxyOptionsUtils;
 import io.gravitee.node.api.configuration.Configuration;
-import io.gravitee.node.vertx.proxy.VertxProxyOptionsUtils;
 import io.reactivex.rxjava3.core.Single;
 import io.vertx.core.http.HttpClientOptions;
 import io.vertx.core.http.HttpHeaders;
@@ -84,7 +84,7 @@ public class VertxResourceRetriever implements ResourceRetriever {
 
         if (useSystemProxy) {
             try {
-                options.setProxyOptions(VertxProxyOptionsUtils.buildProxyOptions(configuration));
+                VertxProxyOptionsUtils.setSystemProxy(options, configuration);
             } catch (Exception e) {
                 log.warn(
                     "JWTPlugin requires a system proxy to be defined to retrieve resource [{}] but some configurations are missing or not well defined: {}",

--- a/src/main/java/io/gravitee/policy/v3/jwt/jwks/retriever/VertxResourceRetriever.java
+++ b/src/main/java/io/gravitee/policy/v3/jwt/jwks/retriever/VertxResourceRetriever.java
@@ -15,9 +15,10 @@
  */
 package io.gravitee.policy.v3.jwt.jwks.retriever;
 
+import static io.gravitee.common.util.VertxProxyOptionsUtils.setSystemProxy;
+
 import com.nimbusds.jose.util.Resource;
 import io.gravitee.node.api.configuration.Configuration;
-import io.gravitee.node.vertx.proxy.VertxProxyOptionsUtils;
 import io.vertx.core.Future;
 import io.vertx.core.Promise;
 import io.vertx.core.Vertx;
@@ -57,7 +58,7 @@ public class VertxResourceRetriever implements ResourceRetriever {
 
         if (useSystemProxy) {
             try {
-                options.setProxyOptions(VertxProxyOptionsUtils.buildProxyOptions(configuration));
+                setSystemProxy(options, configuration);
             } catch (Exception e) {
                 LOGGER.warn(
                     "JWTPlugin requires a system proxy to be defined to retrieve resource [{}] but some configurations are missing or not well defined: {}",

--- a/src/test/java/io/gravitee/policy/jwt/jwk/AbstractJWKTest.java
+++ b/src/test/java/io/gravitee/policy/jwt/jwk/AbstractJWKTest.java
@@ -36,8 +36,8 @@ import java.util.Base64;
 import java.util.Date;
 import java.util.stream.Stream;
 import net.schmizz.sshj.common.Buffer;
+import org.apache.commons.lang3.RandomStringUtils;
 import org.junit.jupiter.params.provider.Arguments;
-import wiremock.org.apache.commons.lang3.RandomStringUtils;
 
 /**
  * @author Jeoffrey HAEYAERT (jeoffrey.haeyaert at graviteesource.com)


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/APIM-XXXX

**Description**

Revert 4.1.4 release <- do not use it with version lower or equal to 4.3.x => 4.1.x

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `4.1.5-revert-4-1-4-release-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/policy/gravitee-policy-jwt/4.1.5-revert-4-1-4-release-SNAPSHOT/gravitee-policy-jwt-4.1.5-revert-4-1-4-release-SNAPSHOT.zip)
  <!-- Version placeholder end -->
