### PR TITLE
fix(dependency): VertxProxyOptionsUtils was moved to gravitee-node

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -29,7 +29,8 @@ Some authorization servers use OAuth2 protocol to provide access tokens. These a
 |1.20.x to 1.21.x    | 3.10.x to 3.14.x
 |1.22.x              | 3.15.x to 3.17.x
 |2.x                 | 3.18.x to 3.20
-|4.x                 | 4.0.x to latest
+|4.x                 | 4.0.x to 4.3.x
+|5.x                 | 4.4.x to latest
 |===
 
 === JWT

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
 
     <groupId>io.gravitee.policy</groupId>
     <artifactId>gravitee-policy-jwt</artifactId>
-    <version>4.1.5</version>
+    <version>5.0.0</version>
 
     <name>Gravitee.io APIM - Policy - JWT</name>
     <description>Validate the token signature and expiration date before sending the API call to the target backend</description>
@@ -30,16 +30,17 @@
     <parent>
         <groupId>io.gravitee</groupId>
         <artifactId>gravitee-parent</artifactId>
-        <version>22.0.2</version>
+        <version>22.1.0</version>
     </parent>
 
     <properties>
-        <gravitee-bom.version>6.0.3</gravitee-bom.version>
-        <gravitee-gateway-api.version>3.0.0</gravitee-gateway-api.version>
+        <gravitee-bom.version>7.0.23</gravitee-bom.version>
+        <gravitee-common.version>4.4.0</gravitee-common.version>
+        <gravitee-gateway-api.version>3.5.0</gravitee-gateway-api.version>
+        <gravitee-node.version>5.18.3</gravitee-node.version>
+        <gravitee-apim.version>4.4.0</gravitee-apim.version>
+
         <gravitee-policy-api.version>1.11.0</gravitee-policy-api.version>
-        <gravitee-node.version>3.1.0</gravitee-node.version>
-        <gravitee-common.version>3.3.3</gravitee-common.version>
-        <gravitee-apim.version>4.1.0-SNAPSHOT</gravitee-apim.version>
 
         <nimbus-jose-jwt.version>9.15.2</nimbus-jose-jwt.version>
         <sshj.version>0.35.0</sshj.version>
@@ -77,6 +78,13 @@
                 <artifactId>gravitee-common</artifactId>
                 <version>${gravitee-common.version}</version>
             </dependency>
+            <dependency>
+                <groupId>io.gravitee.node</groupId>
+                <artifactId>gravitee-node</artifactId>
+                <version>${gravitee-node.version}</version>
+                <scope>import</scope>
+                <type>pom</type>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 
@@ -95,6 +103,16 @@
         <dependency>
             <groupId>io.gravitee.common</groupId>
             <artifactId>gravitee-common</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.gravitee.node</groupId>
+            <artifactId>gravitee-node-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.gravitee.node</groupId>
+            <artifactId>gravitee-node-vertx</artifactId>
             <scope>provided</scope>
         </dependency>
 

--- a/src/main/java/io/gravitee/policy/jwt/jwk/source/VertxResourceRetriever.java
+++ b/src/main/java/io/gravitee/policy/jwt/jwk/source/VertxResourceRetriever.java
@@ -16,8 +16,8 @@
 package io.gravitee.policy.jwt.jwk.source;
 
 import com.nimbusds.jose.util.Resource;
-import io.gravitee.common.util.VertxProxyOptionsUtils;
 import io.gravitee.node.api.configuration.Configuration;
+import io.gravitee.node.vertx.proxy.VertxProxyOptionsUtils;
 import io.reactivex.rxjava3.core.Single;
 import io.vertx.core.http.HttpClientOptions;
 import io.vertx.core.http.HttpHeaders;
@@ -84,7 +84,7 @@ public class VertxResourceRetriever implements ResourceRetriever {
 
         if (useSystemProxy) {
             try {
-                VertxProxyOptionsUtils.setSystemProxy(options, configuration);
+                options.setProxyOptions(VertxProxyOptionsUtils.buildProxyOptions(configuration));
             } catch (Exception e) {
                 log.warn(
                     "JWTPlugin requires a system proxy to be defined to retrieve resource [{}] but some configurations are missing or not well defined: {}",

--- a/src/main/java/io/gravitee/policy/v3/jwt/jwks/retriever/VertxResourceRetriever.java
+++ b/src/main/java/io/gravitee/policy/v3/jwt/jwks/retriever/VertxResourceRetriever.java
@@ -15,10 +15,9 @@
  */
 package io.gravitee.policy.v3.jwt.jwks.retriever;
 
-import static io.gravitee.common.util.VertxProxyOptionsUtils.setSystemProxy;
-
 import com.nimbusds.jose.util.Resource;
 import io.gravitee.node.api.configuration.Configuration;
+import io.gravitee.node.vertx.proxy.VertxProxyOptionsUtils;
 import io.vertx.core.Future;
 import io.vertx.core.Promise;
 import io.vertx.core.Vertx;
@@ -58,7 +57,7 @@ public class VertxResourceRetriever implements ResourceRetriever {
 
         if (useSystemProxy) {
             try {
-                setSystemProxy(options, configuration);
+                options.setProxyOptions(VertxProxyOptionsUtils.buildProxyOptions(configuration));
             } catch (Exception e) {
                 LOGGER.warn(
                     "JWTPlugin requires a system proxy to be defined to retrieve resource [{}] but some configurations are missing or not well defined: {}",

--- a/src/test/java/io/gravitee/policy/jwt/jwk/AbstractJWKTest.java
+++ b/src/test/java/io/gravitee/policy/jwt/jwk/AbstractJWKTest.java
@@ -36,8 +36,8 @@ import java.util.Base64;
 import java.util.Date;
 import java.util.stream.Stream;
 import net.schmizz.sshj.common.Buffer;
-import org.apache.commons.lang3.RandomStringUtils;
 import org.junit.jupiter.params.provider.Arguments;
+import wiremock.org.apache.commons.lang3.RandomStringUtils;
 
 /**
  * @author Jeoffrey HAEYAERT (jeoffrey.haeyaert at graviteesource.com)


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/APIM-6108

Description

Updated APIM version VertxProxyOptionsUtils was moved to gravitee-node

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `5.0.0`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/policy/gravitee-policy-jwt/5.0.0/gravitee-policy-jwt-5.0.0.zip)
  <!-- Version placeholder end -->
