### PR TITLE
feat: make jwks timeouts configurable (3.x)

### DIFF
--- a/src/main/java/io/gravitee/policy/jwt/configuration/JWTPolicyConfiguration.java
+++ b/src/main/java/io/gravitee/policy/jwt/configuration/JWTPolicyConfiguration.java
@@ -35,6 +35,8 @@ public class JWTPolicyConfiguration implements PolicyConfiguration {
     private String userClaim;
     private String clientIdClaim;
     private boolean useSystemProxy;
+    private Integer connectTimeout;
+    private Long requestTimeout;
 
     //getter and setters
     public KeyResolver getPublicKeyResolver() {
@@ -99,5 +101,21 @@ public class JWTPolicyConfiguration implements PolicyConfiguration {
 
     public void setUseSystemProxy(boolean useSystemProxy) {
         this.useSystemProxy = useSystemProxy;
+    }
+
+    public Integer getConnectTimeout() {
+        return connectTimeout;
+    }
+
+    public void setConnectTimeout(Integer connectTimeout) {
+        this.connectTimeout = connectTimeout;
+    }
+
+    public Long getRequestTimeout() {
+        return requestTimeout;
+    }
+
+    public void setRequestTimeout(Long requestTimeout) {
+        this.requestTimeout = requestTimeout;
     }
 }

--- a/src/main/java/io/gravitee/policy/jwt/jwk/provider/JwksUrlJWTProcessorProvider.java
+++ b/src/main/java/io/gravitee/policy/jwt/jwk/provider/JwksUrlJWTProcessorProvider.java
@@ -28,6 +28,7 @@ import io.gravitee.policy.jwt.configuration.JWTPolicyConfiguration;
 import io.gravitee.policy.jwt.jwk.source.JWKSUrlJWKSourceResolver;
 import io.gravitee.policy.jwt.jwk.source.ResourceRetriever;
 import io.gravitee.policy.jwt.jwk.source.VertxResourceRetriever;
+import io.gravitee.policy.v3.jwt.jwks.retriever.RetrieveOptions;
 import io.reactivex.rxjava3.core.Maybe;
 import io.vertx.rxjava3.core.Vertx;
 import java.time.Duration;
@@ -90,7 +91,12 @@ class JwksUrlJWTProcessorProvider implements JWTProcessorProvider {
                 new VertxResourceRetriever(
                     ctx.getComponent(Vertx.class),
                     ctx.getComponent(Configuration.class),
-                    configuration.isUseSystemProxy()
+                    RetrieveOptions
+                        .builder()
+                        .connectTimeout(configuration.getConnectTimeout())
+                        .requestTimeout(configuration.getRequestTimeout())
+                        .useSystemProxy(configuration.isUseSystemProxy())
+                        .build()
                 );
         }
 

--- a/src/main/java/io/gravitee/policy/jwt/jwk/source/VertxResourceRetriever.java
+++ b/src/main/java/io/gravitee/policy/jwt/jwk/source/VertxResourceRetriever.java
@@ -18,6 +18,7 @@ package io.gravitee.policy.jwt.jwk.source;
 import com.nimbusds.jose.util.Resource;
 import io.gravitee.common.util.VertxProxyOptionsUtils;
 import io.gravitee.node.api.configuration.Configuration;
+import io.gravitee.policy.v3.jwt.jwks.retriever.RetrieveOptions;
 import io.reactivex.rxjava3.core.Single;
 import io.vertx.core.http.HttpClientOptions;
 import io.vertx.core.http.HttpHeaders;
@@ -38,16 +39,19 @@ public class VertxResourceRetriever implements ResourceRetriever {
 
     private static final Logger log = LoggerFactory.getLogger(VertxResourceRetriever.class);
     private static final String HTTPS_SCHEME = "https";
-    protected static final int DEFAULT_TIMEOUT = 2000;
 
     private final Vertx vertx;
     private final Configuration configuration;
     private final boolean useSystemProxy;
+    private final int connectTimeout;
+    private final long requestTimeout;
 
-    public VertxResourceRetriever(final Vertx vertx, Configuration configuration, boolean useSystemProxy) {
+    public VertxResourceRetriever(final Vertx vertx, Configuration configuration, RetrieveOptions options) {
         this.vertx = vertx;
         this.configuration = configuration;
-        this.useSystemProxy = useSystemProxy;
+        this.useSystemProxy = options.isUseSystemProxy();
+        this.connectTimeout = options.getConnectTimeout();
+        this.requestTimeout = options.getRequestTimeout();
     }
 
     public Single<Resource> retrieve(String url) {
@@ -61,10 +65,7 @@ public class VertxResourceRetriever implements ResourceRetriever {
 
         HttpClient httpClient = buildHttpClient(finalURL);
 
-        final RequestOptions requestOptions = new RequestOptions()
-            .setMethod(HttpMethod.GET)
-            .setAbsoluteURI(url)
-            .setTimeout(DEFAULT_TIMEOUT);
+        final RequestOptions requestOptions = new RequestOptions().setMethod(HttpMethod.GET).setAbsoluteURI(url).setTimeout(requestTimeout);
 
         return httpClient
             .rxRequest(requestOptions)
@@ -80,7 +81,7 @@ public class VertxResourceRetriever implements ResourceRetriever {
     }
 
     private HttpClient buildHttpClient(URL url) {
-        HttpClientOptions options = new HttpClientOptions().setConnectTimeout(DEFAULT_TIMEOUT);
+        HttpClientOptions options = new HttpClientOptions().setConnectTimeout(connectTimeout);
 
         if (useSystemProxy) {
             try {

--- a/src/main/java/io/gravitee/policy/v3/jwt/JWTPolicyV3.java
+++ b/src/main/java/io/gravitee/policy/v3/jwt/JWTPolicyV3.java
@@ -34,6 +34,7 @@ import io.gravitee.policy.jwt.utils.TokenExtractor;
 import io.gravitee.policy.v3.jwt.exceptions.InvalidTokenException;
 import io.gravitee.policy.v3.jwt.jwks.URLJWKSourceResolver;
 import io.gravitee.policy.v3.jwt.jwks.hmac.MACJWKSourceResolver;
+import io.gravitee.policy.v3.jwt.jwks.retriever.RetrieveOptions;
 import io.gravitee.policy.v3.jwt.jwks.retriever.VertxResourceRetriever;
 import io.gravitee.policy.v3.jwt.jwks.rsa.RSAJWKSourceResolver;
 import io.gravitee.policy.v3.jwt.processor.*;
@@ -261,7 +262,12 @@ public class JWTPolicyV3 {
                     new VertxResourceRetriever(
                         executionContext.getComponent(Vertx.class),
                         executionContext.getComponent(Configuration.class),
-                        configuration.isUseSystemProxy()
+                        RetrieveOptions
+                            .builder()
+                            .connectTimeout(configuration.getConnectTimeout())
+                            .requestTimeout(configuration.getRequestTimeout())
+                            .useSystemProxy(configuration.isUseSystemProxy())
+                            .build()
                     )
                 )
             );

--- a/src/main/java/io/gravitee/policy/v3/jwt/jwks/URLJWKSourceResolver.java
+++ b/src/main/java/io/gravitee/policy/v3/jwt/jwks/URLJWKSourceResolver.java
@@ -64,9 +64,10 @@ public class URLJWKSourceResolver<C extends SecurityContext> implements JWKSourc
             .thenCompose(this::readJwkSourceFromResource)
             .exceptionally(ex -> {
                 if (cachedJWKSource != null) {
-                    LOGGER.warn("Failed to retreive JWKS from URL {}. Using old cached JWKS", jwksUrl, ex);
+                    LOGGER.warn("Failed to retrieve JWKS from URL {}. Using old cached JWKS", jwksUrl, ex);
                     return cachedJWKSource.getJwkSource();
                 }
+                LOGGER.error("Failed to retrieve JWKS from URL, returning null", ex);
                 return null;
             });
     }

--- a/src/main/java/io/gravitee/policy/v3/jwt/jwks/retriever/RetrieveOptions.java
+++ b/src/main/java/io/gravitee/policy/v3/jwt/jwks/retriever/RetrieveOptions.java
@@ -1,0 +1,44 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.policy.v3.jwt.jwks.retriever;
+
+import java.util.Optional;
+import lombok.Builder;
+import lombok.Value;
+
+/**
+ * @author Antoine CORDIER (antoine.cordier at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+@Value
+@Builder
+public class RetrieveOptions {
+
+    private static final int DEFAULT_CONNECT_TIMEOUT = 2000;
+    private static final long DEFAULT_REQUEST_TIMEOUT = 2000L;
+
+    boolean useSystemProxy;
+    Integer connectTimeout;
+    Long requestTimeout;
+
+    public int getConnectTimeout() {
+        return Optional.ofNullable(connectTimeout).orElse(DEFAULT_CONNECT_TIMEOUT);
+    }
+
+    public long getRequestTimeout() {
+        return Optional.ofNullable(requestTimeout).orElse(DEFAULT_REQUEST_TIMEOUT);
+    }
+}

--- a/src/main/java/io/gravitee/policy/v3/jwt/jwks/retriever/VertxResourceRetriever.java
+++ b/src/main/java/io/gravitee/policy/v3/jwt/jwks/retriever/VertxResourceRetriever.java
@@ -41,16 +41,20 @@ public class VertxResourceRetriever implements ResourceRetriever {
     private final Vertx vertx;
     private final Configuration configuration;
     private final boolean useSystemProxy;
+    private final int connectTimeout;
+    private final long requestTimeout;
 
-    public VertxResourceRetriever(final Vertx vertx, Configuration configuration, boolean useSystemProxy) {
+    public VertxResourceRetriever(final Vertx vertx, Configuration configuration, RetrieveOptions options) {
         this.vertx = vertx;
         this.configuration = configuration;
-        this.useSystemProxy = useSystemProxy;
+        this.useSystemProxy = options.isUseSystemProxy();
+        this.connectTimeout = options.getConnectTimeout();
+        this.requestTimeout = options.getRequestTimeout();
     }
 
     @Override
     public CompletableFuture<Resource> retrieve(URL url) {
-        HttpClientOptions options = new HttpClientOptions().setConnectTimeout(2000);
+        HttpClientOptions options = new HttpClientOptions().setConnectTimeout(connectTimeout);
 
         if (useSystemProxy) {
             try {
@@ -76,7 +80,7 @@ public class VertxResourceRetriever implements ResourceRetriever {
         final RequestOptions requestOptions = new RequestOptions()
             .setMethod(HttpMethod.GET)
             .setAbsoluteURI(url.toString())
-            .setTimeout(2000L);
+            .setTimeout(requestTimeout);
 
         final Future<HttpClientRequest> futureRequest = httpClient.request(requestOptions);
 

--- a/src/main/java/io/gravitee/policy/v3/jwt/processor/AbstractKeyProcessor.java
+++ b/src/main/java/io/gravitee/policy/v3/jwt/processor/AbstractKeyProcessor.java
@@ -48,6 +48,9 @@ public abstract class AbstractKeyProcessor<C extends SecurityContext> implements
         return jwkSourceResolver
             .resolve()
             .thenCompose(jwkSource -> {
+                if (jwkSource == null) {
+                    return CompletableFuture.failedFuture(new IllegalStateException("could not resolve jwk source"));
+                }
                 ConfigurableJWTProcessor<C> jwtProcessor = new DefaultJWTProcessor<>();
                 jwtProcessor.setJWTClaimsSetVerifier(claimsVerifier);
                 jwtProcessor.setJWSKeySelector(jwsKeySelector(jwkSource, signature));

--- a/src/main/resources/schemas/schema-form.json
+++ b/src/main/resources/schemas/schema-form.json
@@ -62,6 +62,18 @@
         "expression-language": true
       }
     },
+    "connectTimeout": {
+      "title": "JWKS URL connect timeout",
+      "description": "Only applies when the resolver is JWKS_URL",
+      "type": "integer",
+      "default": 2000
+    },
+    "requestTimeout": {
+      "title": "JWKS URL request timeout",
+      "description": "Only applies when the resolver is JWKS_URL",
+      "type": "integer",
+      "default": 2000
+    },
     "useSystemProxy" : {
       "title": "Use system proxy",
       "description": "Use system proxy (make sense only when resolver is set to JWKS_URL)",


### PR DESCRIPTION
see https://gravitee.atlassian.net/browse/APIM-7292
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `3.1.0-apim-7292-set-jwks-timeouts-3-x-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/policy/gravitee-policy-jwt/3.1.0-apim-7292-set-jwks-timeouts-3-x-SNAPSHOT/gravitee-policy-jwt-3.1.0-apim-7292-set-jwks-timeouts-3-x-SNAPSHOT.zip)
  <!-- Version placeholder end -->
