### PR TITLE
Update policy for kafka gateway

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ version: 2.1
 setup: true
 
 orbs:
-    gravitee: gravitee-io/gravitee@4.1.1
+    gravitee: gravitee-io/gravitee@4.8.0
 
 # our single workflow, that triggers the setup job defined above, filters on tag and branches are needed otherwise
 # some workflow and job will not be triggered for tags (default CircleCI behavior)

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,13 +1,9 @@
-**Issue**
+## Issue
 
-https://gravitee.atlassian.net/browse/APIM-XXXX
+https://gravitee.atlassian.net/browse/XXXXX
 
-**Description**
+## Description
 
 A small description of what you did in that PR.
 
-**Additional context**
-
-<!-- Add any other context about the PR here -->
-<!-- It can be links to other PRs or docs or drawing -->
-<!-- Or reproduction steps in case of bug fix -->
+## Additional context

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,25 +1,3 @@
 {
-    "extends": ["config:base", ":label(dependencies)"],
-    "rebaseWhen": "conflicted",
-    "packageRules": [
-        {
-            "matchDatasources": ["orb"],
-            "matchUpdateTypes": ["patch", "minor"],
-            "automerge": true,
-            "automergeType": "branch",
-            "semanticCommitType": "ci"
-        },
-        {
-            "matchDepTypes": ["provided", "test", "build", "import", "parent"],
-            "matchUpdateTypes": ["patch", "minor"],
-            "automerge": true,
-            "automergeType": "branch",
-            "semanticCommitType": "chore"
-        },
-        {
-            "matchDepTypes": ["provided", "test", "build", "import", "parent"],
-            "matchUpdateTypes": ["major"],
-            "semanticCommitType": "chore"
-        }
-    ]
+    "extends": ["github>gravitee-io/renovate-config:policy"]
 }

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
 
     <groupId>io.gravitee.policy</groupId>
     <artifactId>gravitee-policy-jwt</artifactId>
-    <version>5.1.0</version>
+    <version>6.0.0-apim-7143-impl-security-chain-SNAPSHOT</version>
 
     <name>Gravitee.io APIM - Policy - JWT</name>
     <description>Validate the token signature and expiration date before sending the API call to the target backend</description>
@@ -30,22 +30,14 @@
     <parent>
         <groupId>io.gravitee</groupId>
         <artifactId>gravitee-parent</artifactId>
-        <version>22.1.0</version>
+        <version>22.2.1</version>
     </parent>
 
     <properties>
-        <gravitee-bom.version>7.0.23</gravitee-bom.version>
-        <gravitee-common.version>4.4.0</gravitee-common.version>
-        <gravitee-gateway-api.version>3.5.0</gravitee-gateway-api.version>
-        <gravitee-node.version>5.18.3</gravitee-node.version>
-        <gravitee-apim.version>4.4.0</gravitee-apim.version>
-
-        <gravitee-policy-api.version>1.11.0</gravitee-policy-api.version>
+        <gravitee-apim.version>4.6.0-SNAPSHOT</gravitee-apim.version>
 
         <nimbus-jose-jwt.version>9.15.2</nimbus-jose-jwt.version>
         <sshj.version>0.35.0</sshj.version>
-        <guava.version>31.1-jre</guava.version>
-
         <maven-plugin-assembly.version>3.6.0</maven-plugin-assembly.version>
         <maven-plugin-properties.version>1.1.0</maven-plugin-properties.version>
 
@@ -57,31 +49,9 @@
         <dependencies>
             <!-- Import bom to properly inherit all dependencies -->
             <dependency>
-                <groupId>io.gravitee</groupId>
-                <artifactId>gravitee-bom</artifactId>
-                <version>${gravitee-bom.version}</version>
-                <scope>import</scope>
-                <type>pom</type>
-            </dependency>
-            <dependency>
-                <groupId>io.gravitee.policy</groupId>
-                <artifactId>gravitee-policy-api</artifactId>
-                <version>${gravitee-policy-api.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>io.gravitee.gateway</groupId>
-                <artifactId>gravitee-gateway-api</artifactId>
-                <version>${gravitee-gateway-api.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>io.gravitee.common</groupId>
-                <artifactId>gravitee-common</artifactId>
-                <version>${gravitee-common.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>io.gravitee.node</groupId>
-                <artifactId>gravitee-node</artifactId>
-                <version>${gravitee-node.version}</version>
+                <groupId>io.gravitee.apim</groupId>
+                <artifactId>gravitee-apim-bom</artifactId>
+                <version>${gravitee-apim.version}</version>
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>
@@ -116,10 +86,20 @@
             <scope>provided</scope>
         </dependency>
 
+        <!--
+            nimbus-jose-jwt is kept at version 9.15.2 on purpose because 9.25.4 introduced a breaking change in the way empty signatures are handled
+            https://bitbucket.org/connect2id/nimbus-jose-jwt/src/94a2e4d11ce322966d30a551a2d482936b588c87/CHANGELOG.txt#lines-1477:1481 
+        -->
         <dependency>
             <groupId>com.nimbusds</groupId>
             <artifactId>nimbus-jose-jwt</artifactId>
             <version>${nimbus-jose-jwt.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+            <scope>provided</scope>
         </dependency>
 
         <dependency>
@@ -250,15 +230,6 @@
                         </goals>
                     </execution>
                 </executions>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-javadoc-plugin</artifactId>
-                <version>${maven-javadoc-plugin.version}</version>
-                <configuration>
-                    <additionalJOption>-Xdoclint:none</additionalJOption>
-                    <source>8</source>
-                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/pom.xml
+++ b/pom.xml
@@ -88,7 +88,7 @@
 
         <!--
             nimbus-jose-jwt is kept at version 9.15.2 on purpose because 9.25.4 introduced a breaking change in the way empty signatures are handled
-            https://bitbucket.org/connect2id/nimbus-jose-jwt/src/94a2e4d11ce322966d30a551a2d482936b588c87/CHANGELOG.txt#lines-1477:1481 
+            https://bitbucket.org/connect2id/nimbus-jose-jwt/src/94a2e4d11ce322966d30a551a2d482936b588c87/CHANGELOG.txt#lines-1477:1481
         -->
         <dependency>
             <groupId>com.nimbusds</groupId>
@@ -140,6 +140,12 @@
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-core</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.kafka</groupId>
+            <artifactId>kafka-clients</artifactId>
             <scope>provided</scope>
         </dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,6 @@
     <properties>
         <gravitee-apim.version>4.6.0-SNAPSHOT</gravitee-apim.version>
 
-        <nimbus-jose-jwt.version>9.15.2</nimbus-jose-jwt.version>
         <sshj.version>0.35.0</sshj.version>
         <maven-plugin-assembly.version>3.6.0</maven-plugin-assembly.version>
         <maven-plugin-properties.version>1.1.0</maven-plugin-properties.version>
@@ -86,14 +85,10 @@
             <scope>provided</scope>
         </dependency>
 
-        <!--
-            nimbus-jose-jwt is kept at version 9.15.2 on purpose because 9.25.4 introduced a breaking change in the way empty signatures are handled
-            https://bitbucket.org/connect2id/nimbus-jose-jwt/src/94a2e4d11ce322966d30a551a2d482936b588c87/CHANGELOG.txt#lines-1477:1481
-        -->
         <dependency>
             <groupId>com.nimbusds</groupId>
             <artifactId>nimbus-jose-jwt</artifactId>
-            <version>${nimbus-jose-jwt.version}</version>
+            <scope>provided</scope>
         </dependency>
 
         <dependency>

--- a/src/main/java/io/gravitee/policy/jwt/jwk/provider/DefaultJWTProcessorProvider.java
+++ b/src/main/java/io/gravitee/policy/jwt/jwk/provider/DefaultJWTProcessorProvider.java
@@ -17,7 +17,7 @@ package io.gravitee.policy.jwt.jwk.provider;
 
 import com.nimbusds.jose.proc.SecurityContext;
 import com.nimbusds.jwt.proc.JWTProcessor;
-import io.gravitee.gateway.reactive.api.context.HttpExecutionContext;
+import io.gravitee.gateway.reactive.api.context.base.BaseExecutionContext;
 import io.gravitee.policy.jwt.configuration.JWTPolicyConfiguration;
 import io.gravitee.policy.v3.jwt.resolver.KeyResolver;
 import io.reactivex.rxjava3.core.Maybe;
@@ -48,7 +48,7 @@ public class DefaultJWTProcessorProvider implements JWTProcessorProvider {
     }
 
     @Override
-    public Maybe<JWTProcessor<SecurityContext>> provide(HttpExecutionContext ctx) {
+    public Maybe<JWTProcessor<SecurityContext>> provide(BaseExecutionContext ctx) {
         if (jwtProcessorProvider == null) {
             return Maybe.empty();
         }

--- a/src/main/java/io/gravitee/policy/jwt/jwk/provider/GatewayKeysJWTProcessorProvider.java
+++ b/src/main/java/io/gravitee/policy/jwt/jwk/provider/GatewayKeysJWTProcessorProvider.java
@@ -26,7 +26,7 @@ import com.nimbusds.jose.proc.SecurityContext;
 import com.nimbusds.jwt.proc.DefaultJWTProcessor;
 import com.nimbusds.jwt.proc.JWTProcessor;
 import io.gravitee.common.util.EnvironmentUtils;
-import io.gravitee.gateway.reactive.api.context.HttpExecutionContext;
+import io.gravitee.gateway.reactive.api.context.base.BaseExecutionContext;
 import io.gravitee.policy.jwt.configuration.JWTPolicyConfiguration;
 import io.gravitee.policy.jwt.jwk.selector.IssuerAwareJWSKeySelector;
 import io.gravitee.policy.jwt.jwk.selector.NoKidJWSVerificationKeySelector;
@@ -69,11 +69,11 @@ class GatewayKeysJWTProcessorProvider implements JWTProcessorProvider {
      * Creates the {@link JWTProcessor} with all the keys defined at gateway level and cache it for reuse.
      */
     @Override
-    public Maybe<JWTProcessor<SecurityContext>> provide(HttpExecutionContext ctx) {
+    public Maybe<JWTProcessor<SecurityContext>> provide(BaseExecutionContext ctx) {
         return Maybe.fromCallable(() -> buildJWTProcessor(ctx));
     }
 
-    private JWTProcessor<SecurityContext> buildJWTProcessor(HttpExecutionContext ctx) {
+    private JWTProcessor<SecurityContext> buildJWTProcessor(BaseExecutionContext ctx) {
         final JWSAlgorithm alg = configuration.getSignature().getAlg();
         final Map<String, List<JWK>> jwkByIssuer = loadFromConfiguration(alg, ctx.getComponent(ConfigurableEnvironment.class));
         final Map<String, JWSKeySelector<SecurityContext>> selectors = createJWSKeySelectors(alg, jwkByIssuer);

--- a/src/main/java/io/gravitee/policy/jwt/jwk/provider/GivenKeyJWTProcessorProvider.java
+++ b/src/main/java/io/gravitee/policy/jwt/jwk/provider/GivenKeyJWTProcessorProvider.java
@@ -23,7 +23,7 @@ import com.nimbusds.jose.proc.JWSKeySelector;
 import com.nimbusds.jose.proc.SecurityContext;
 import com.nimbusds.jwt.proc.DefaultJWTProcessor;
 import com.nimbusds.jwt.proc.JWTProcessor;
-import io.gravitee.gateway.reactive.api.context.HttpExecutionContext;
+import io.gravitee.gateway.reactive.api.context.base.BaseExecutionContext;
 import io.gravitee.policy.jwt.configuration.JWTPolicyConfiguration;
 import io.gravitee.policy.jwt.jwk.selector.NoKidJWSVerificationKeySelector;
 import io.gravitee.policy.jwt.utils.JWKBuilder;
@@ -53,7 +53,7 @@ class GivenKeyJWTProcessorProvider implements JWTProcessorProvider {
      * Creates the {@link JWTProcessor} with the given key defined at the policy configuration level and cache it for reuse.
      */
     @Override
-    public Maybe<JWTProcessor<SecurityContext>> provide(HttpExecutionContext ctx) {
+    public Maybe<JWTProcessor<SecurityContext>> provide(BaseExecutionContext ctx) {
         return Maybe.fromCallable(() -> buildJWTProcessor(ctx.getInternalAttribute(ATTR_INTERNAL_RESOLVED_PARAMETER)));
     }
 

--- a/src/main/java/io/gravitee/policy/jwt/jwk/provider/JWTProcessorProvider.java
+++ b/src/main/java/io/gravitee/policy/jwt/jwk/provider/JWTProcessorProvider.java
@@ -17,7 +17,7 @@ package io.gravitee.policy.jwt.jwk.provider;
 
 import com.nimbusds.jose.proc.SecurityContext;
 import com.nimbusds.jwt.proc.JWTProcessor;
-import io.gravitee.gateway.reactive.api.context.HttpExecutionContext;
+import io.gravitee.gateway.reactive.api.context.base.BaseExecutionContext;
 import io.reactivex.rxjava3.core.Maybe;
 
 /**
@@ -34,5 +34,5 @@ public interface JWTProcessorProvider {
      * @param ctx the current execution context.
      * @return a {@link Maybe} containing an {@link JWTProcessor}.
      */
-    Maybe<JWTProcessor<SecurityContext>> provide(final HttpExecutionContext ctx);
+    Maybe<JWTProcessor<SecurityContext>> provide(final BaseExecutionContext ctx);
 }

--- a/src/main/java/io/gravitee/policy/jwt/jwk/provider/JwksUrlJWTProcessorProvider.java
+++ b/src/main/java/io/gravitee/policy/jwt/jwk/provider/JwksUrlJWTProcessorProvider.java
@@ -22,7 +22,7 @@ import com.nimbusds.jose.proc.JWSVerificationKeySelector;
 import com.nimbusds.jose.proc.SecurityContext;
 import com.nimbusds.jwt.proc.DefaultJWTProcessor;
 import com.nimbusds.jwt.proc.JWTProcessor;
-import io.gravitee.gateway.reactive.api.context.HttpExecutionContext;
+import io.gravitee.gateway.reactive.api.context.base.BaseExecutionContext;
 import io.gravitee.node.api.configuration.Configuration;
 import io.gravitee.policy.jwt.configuration.JWTPolicyConfiguration;
 import io.gravitee.policy.jwt.jwk.source.JWKSUrlJWKSourceResolver;
@@ -59,11 +59,11 @@ class JwksUrlJWTProcessorProvider implements JWTProcessorProvider {
      * @see JWKSUrlJWKSourceResolver
      */
     @Override
-    public Maybe<JWTProcessor<SecurityContext>> provide(HttpExecutionContext ctx) {
+    public Maybe<JWTProcessor<SecurityContext>> provide(BaseExecutionContext ctx) {
         return Maybe.defer(() -> buildJWTProcessor(ctx, ctx.getInternalAttribute(ATTR_INTERNAL_RESOLVED_PARAMETER)));
     }
 
-    private Maybe<JWTProcessor<SecurityContext>> buildJWTProcessor(HttpExecutionContext ctx, String url) {
+    private Maybe<JWTProcessor<SecurityContext>> buildJWTProcessor(BaseExecutionContext ctx, String url) {
         // Create a source resolver to resolve the Json Web Keystore from an url.
         final JWKSUrlJWKSourceResolver<SecurityContext> sourceResolver = new JWKSUrlJWKSourceResolver<>(
             url,
@@ -85,7 +85,7 @@ class JwksUrlJWTProcessorProvider implements JWTProcessorProvider {
         return sourceResolver.initialize().andThen(Maybe.just(jwtProcessor));
     }
 
-    private ResourceRetriever getResourceRetriever(HttpExecutionContext ctx) {
+    private ResourceRetriever getResourceRetriever(BaseExecutionContext ctx) {
         if (resourceRetriever == null) {
             resourceRetriever =
                 new VertxResourceRetriever(

--- a/src/main/java/io/gravitee/policy/jwt/jwk/source/VertxResourceRetriever.java
+++ b/src/main/java/io/gravitee/policy/jwt/jwk/source/VertxResourceRetriever.java
@@ -67,7 +67,10 @@ public class VertxResourceRetriever implements ResourceRetriever {
 
         HttpClient httpClient = buildHttpClient(finalURL);
 
-        final RequestOptions requestOptions = new RequestOptions().setMethod(HttpMethod.GET).setAbsoluteURI(url).setTimeout(requestTimeout);
+        final RequestOptions requestOptions = new RequestOptions()
+            .setMethod(HttpMethod.GET)
+            .setAbsoluteURI(finalURL)
+            .setTimeout(requestTimeout);
 
         return httpClient
             .rxRequest(requestOptions)

--- a/src/main/java/io/gravitee/policy/jwt/utils/TokenExtractor.java
+++ b/src/main/java/io/gravitee/policy/jwt/utils/TokenExtractor.java
@@ -16,10 +16,10 @@
 package io.gravitee.policy.jwt.utils;
 
 import io.gravitee.common.util.MultiValueMap;
+import io.gravitee.gateway.api.Request;
 import io.gravitee.gateway.api.http.HttpHeaderNames;
 import io.gravitee.gateway.api.http.HttpHeaders;
-import io.gravitee.gateway.reactive.api.context.HttpRequest;
-import io.gravitee.gateway.reactive.api.context.Request;
+import io.gravitee.gateway.reactive.api.context.http.HttpPlainRequest;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.util.ObjectUtils;
@@ -48,7 +48,7 @@ public class TokenExtractor {
      *
      * @return the jwt token as string, {@link Optional#empty()} if no token has been found.
      */
-    public static Optional<String> extract(HttpRequest request) {
+    public static Optional<String> extract(HttpPlainRequest request) {
         return extractFromHeaders(request.headers()).or(() -> extractFromParameters(request.parameters()));
     }
 
@@ -57,7 +57,7 @@ public class TokenExtractor {
      *
      * @param request the request to extract the JWT token from.
      * @return the jwt token as string or <code>null</code> if no token has been found.
-     * @see #extract(HttpRequest)
+     * @see #extract(HttpPlainRequest)
      */
     @Deprecated
     public static String extract(io.gravitee.gateway.api.Request request) {

--- a/src/main/java/io/gravitee/policy/v3/jwt/jwks/hmac/MACJWKSourceResolver.java
+++ b/src/main/java/io/gravitee/policy/v3/jwt/jwks/hmac/MACJWKSourceResolver.java
@@ -23,6 +23,7 @@ import com.nimbusds.jose.jwk.source.JWKSource;
 import com.nimbusds.jose.proc.SecurityContext;
 import io.gravitee.policy.v3.jwt.jwks.JWKSourceResolver;
 import io.gravitee.policy.v3.jwt.resolver.SignatureKeyResolver;
+import java.text.ParseException;
 import java.util.concurrent.CompletableFuture;
 
 /**
@@ -37,7 +38,7 @@ public class MACJWKSourceResolver<C extends SecurityContext> implements JWKSourc
         this.jwk = new OctetSequenceKey.Builder(secretKey.getBytes()).build();
     }
 
-    public MACJWKSourceResolver(SignatureKeyResolver publicKeyResolver) {
+    public MACJWKSourceResolver(SignatureKeyResolver publicKeyResolver) throws ParseException {
         this(publicKeyResolver.resolve());
     }
 

--- a/src/main/java/io/gravitee/policy/v3/jwt/jwks/rsa/RSAJWKSourceResolver.java
+++ b/src/main/java/io/gravitee/policy/v3/jwt/jwks/rsa/RSAJWKSourceResolver.java
@@ -26,6 +26,7 @@ import io.gravitee.policy.jwt.utils.PublicKeyHelper;
 import io.gravitee.policy.v3.jwt.jwks.JWKSourceResolver;
 import io.gravitee.policy.v3.jwt.resolver.SignatureKeyResolver;
 import java.security.interfaces.RSAPublicKey;
+import java.text.ParseException;
 import java.util.concurrent.CompletableFuture;
 
 /**
@@ -53,7 +54,7 @@ public class RSAJWKSourceResolver<C extends SecurityContext> implements JWKSourc
         this.jwk = new RSAKey.Builder(rsaPublicKey).build();
     }
 
-    public RSAJWKSourceResolver(SignatureKeyResolver publicKeyResolver) {
+    public RSAJWKSourceResolver(SignatureKeyResolver publicKeyResolver) throws ParseException {
         this(publicKeyResolver.resolve());
     }
 

--- a/src/main/java/io/gravitee/policy/v3/jwt/resolver/GatewaySignatureKeyResolver.java
+++ b/src/main/java/io/gravitee/policy/v3/jwt/resolver/GatewaySignatureKeyResolver.java
@@ -43,23 +43,21 @@ public class GatewaySignatureKeyResolver implements SignatureKeyResolver {
     }
 
     @Override
-    public String resolve() {
-        try {
-            final JWT jwt = JWTParser.parse(token);
-
-            final String iss = jwt.getJWTClaimsSet().getIssuer();
-            String keyId = ((JWSHeader) jwt.getHeader()).getKeyID();
-
-            if (keyId == null || keyId.isEmpty()) {
-                keyId = DEFAULT_KID;
-            }
-
-            String publicKey = environment.getProperty(String.format(KEY_PROPERTY, iss, keyId));
-            return (publicKey == null || publicKey.trim().isEmpty()) ? null : publicKey;
-        } catch (ParseException pe) {
-            LOGGER.debug("Unexpected error while parsing JWT", pe);
+    public String resolve() throws ParseException {
+        if (token == null || token.isEmpty()) {
+            return null;
         }
 
-        return null;
+        final JWT jwt = JWTParser.parse(token);
+
+        final String iss = jwt.getJWTClaimsSet().getIssuer();
+        String keyId = ((JWSHeader) jwt.getHeader()).getKeyID();
+
+        if (keyId == null || keyId.isEmpty()) {
+            keyId = DEFAULT_KID;
+        }
+
+        String publicKey = environment.getProperty(String.format(KEY_PROPERTY, iss, keyId));
+        return (publicKey == null || publicKey.trim().isEmpty()) ? null : publicKey;
     }
 }

--- a/src/main/java/io/gravitee/policy/v3/jwt/resolver/SignatureKeyResolver.java
+++ b/src/main/java/io/gravitee/policy/v3/jwt/resolver/SignatureKeyResolver.java
@@ -15,10 +15,12 @@
  */
 package io.gravitee.policy.v3.jwt.resolver;
 
+import java.text.ParseException;
+
 /**
  * @author David BRASSELY (david.brassely at graviteesource.com)
  * @author GraviteeSource Team
  */
 public interface SignatureKeyResolver {
-    String resolve();
+    String resolve() throws ParseException;
 }

--- a/src/main/java/io/gravitee/policy/v3/jwt/resolver/TemplatableSignatureKeyResolver.java
+++ b/src/main/java/io/gravitee/policy/v3/jwt/resolver/TemplatableSignatureKeyResolver.java
@@ -16,6 +16,7 @@
 package io.gravitee.policy.v3.jwt.resolver;
 
 import io.gravitee.el.TemplateEngine;
+import java.text.ParseException;
 
 /**
  * @author David BRASSELY (david.brassely at graviteesource.com)
@@ -32,7 +33,7 @@ public class TemplatableSignatureKeyResolver implements SignatureKeyResolver {
     }
 
     @Override
-    public String resolve() {
+    public String resolve() throws ParseException {
         String publicKey = keyResolver.resolve();
         return templateEngine.getValue(publicKey, String.class);
     }

--- a/src/test/java/io/gravitee/policy/jwt/JWTPolicyTest.java
+++ b/src/test/java/io/gravitee/policy/jwt/JWTPolicyTest.java
@@ -49,8 +49,8 @@ import io.gravitee.common.http.HttpStatusCode;
 import io.gravitee.common.security.jwt.LazyJWT;
 import io.gravitee.gateway.api.http.HttpHeaderNames;
 import io.gravitee.gateway.api.http.HttpHeaders;
-import io.gravitee.gateway.reactive.api.context.HttpExecutionContext;
-import io.gravitee.gateway.reactive.api.context.Request;
+import io.gravitee.gateway.reactive.api.context.http.HttpPlainExecutionContext;
+import io.gravitee.gateway.reactive.api.context.http.HttpPlainRequest;
 import io.gravitee.gateway.reactive.api.policy.SecurityToken;
 import io.gravitee.policy.jwt.configuration.JWTPolicyConfiguration;
 import io.gravitee.policy.jwt.jwk.provider.DefaultJWTProcessorProvider;
@@ -58,7 +58,6 @@ import io.gravitee.reporter.api.v4.metric.Metrics;
 import io.reactivex.rxjava3.core.Completable;
 import io.reactivex.rxjava3.core.Maybe;
 import io.reactivex.rxjava3.observers.TestObserver;
-import java.text.ParseException;
 import java.util.Collections;
 import java.util.Date;
 import java.util.List;
@@ -107,10 +106,10 @@ class JWTPolicyTest {
     private JWTProcessor<SecurityContext> jwtProcessor;
 
     @Mock
-    private HttpExecutionContext ctx;
+    private HttpPlainExecutionContext ctx;
 
     @Mock
-    private Request request;
+    private HttpPlainRequest request;
 
     private JWTPolicy cut;
 

--- a/src/test/java/io/gravitee/policy/jwt/jwk/AbstractJWKTest.java
+++ b/src/test/java/io/gravitee/policy/jwt/jwk/AbstractJWKTest.java
@@ -36,8 +36,8 @@ import java.util.Base64;
 import java.util.Date;
 import java.util.stream.Stream;
 import net.schmizz.sshj.common.Buffer;
+import org.apache.commons.lang3.RandomStringUtils;
 import org.junit.jupiter.params.provider.Arguments;
-import wiremock.org.apache.commons.lang3.RandomStringUtils;
 
 /**
  * @author Jeoffrey HAEYAERT (jeoffrey.haeyaert at graviteesource.com)

--- a/src/test/java/io/gravitee/policy/jwt/jwk/provider/DefaultJWTProcessorProviderTest.java
+++ b/src/test/java/io/gravitee/policy/jwt/jwk/provider/DefaultJWTProcessorProviderTest.java
@@ -23,7 +23,7 @@ import static org.mockito.Mockito.*;
 import com.nimbusds.jose.proc.SecurityContext;
 import com.nimbusds.jwt.proc.JWTProcessor;
 import io.gravitee.el.TemplateEngine;
-import io.gravitee.gateway.reactive.api.context.HttpExecutionContext;
+import io.gravitee.gateway.reactive.api.context.base.BaseExecutionContext;
 import io.gravitee.policy.jwt.configuration.JWTPolicyConfiguration;
 import io.gravitee.policy.jwt.jwk.AbstractJWKTest;
 import io.gravitee.policy.v3.jwt.resolver.KeyResolver;
@@ -54,7 +54,7 @@ class DefaultJWTProcessorProviderTest extends AbstractJWKTest {
     private JWTPolicyConfiguration configuration;
 
     @Mock
-    private HttpExecutionContext ctx;
+    private BaseExecutionContext ctx;
 
     @Mock
     private TemplateEngine templateEngine;

--- a/src/test/java/io/gravitee/policy/jwt/jwk/provider/GatewayKeysJWTProcessorProviderTest.java
+++ b/src/test/java/io/gravitee/policy/jwt/jwk/provider/GatewayKeysJWTProcessorProviderTest.java
@@ -23,7 +23,7 @@ import com.nimbusds.jose.jwk.RSAKey;
 import com.nimbusds.jose.proc.SecurityContext;
 import com.nimbusds.jwt.proc.DefaultJWTProcessor;
 import com.nimbusds.jwt.proc.JWTProcessor;
-import io.gravitee.gateway.reactive.api.context.HttpExecutionContext;
+import io.gravitee.gateway.reactive.api.context.base.BaseExecutionContext;
 import io.gravitee.policy.jwt.alg.Signature;
 import io.gravitee.policy.jwt.configuration.JWTPolicyConfiguration;
 import io.gravitee.policy.jwt.jwk.AbstractJWKTest;
@@ -54,7 +54,7 @@ class GatewayKeysJWTProcessorProviderTest extends AbstractJWKTest {
     private JWTPolicyConfiguration configuration;
 
     @Mock
-    private HttpExecutionContext ctx;
+    private BaseExecutionContext ctx;
 
     private MockEnvironment environment;
 

--- a/src/test/java/io/gravitee/policy/jwt/jwk/provider/GivenKeyJWTProcessorProviderTest.java
+++ b/src/test/java/io/gravitee/policy/jwt/jwk/provider/GivenKeyJWTProcessorProviderTest.java
@@ -24,7 +24,7 @@ import com.nimbusds.jose.jwk.RSAKey;
 import com.nimbusds.jose.proc.SecurityContext;
 import com.nimbusds.jwt.proc.DefaultJWTProcessor;
 import com.nimbusds.jwt.proc.JWTProcessor;
-import io.gravitee.gateway.reactive.api.context.HttpExecutionContext;
+import io.gravitee.gateway.reactive.api.context.base.BaseExecutionContext;
 import io.gravitee.policy.jwt.alg.Signature;
 import io.gravitee.policy.jwt.configuration.JWTPolicyConfiguration;
 import io.gravitee.policy.jwt.jwk.AbstractJWKTest;
@@ -50,7 +50,7 @@ class GivenKeyJWTProcessorProviderTest extends AbstractJWKTest {
     private JWTPolicyConfiguration configuration;
 
     @Mock
-    private HttpExecutionContext ctx;
+    private BaseExecutionContext ctx;
 
     @ParameterizedTest
     @MethodSource("provideRSAParameters")

--- a/src/test/java/io/gravitee/policy/jwt/jwk/provider/JwksUrlJWTProcessorProviderTest.java
+++ b/src/test/java/io/gravitee/policy/jwt/jwk/provider/JwksUrlJWTProcessorProviderTest.java
@@ -28,7 +28,7 @@ import com.nimbusds.jose.proc.SecurityContext;
 import com.nimbusds.jose.util.Resource;
 import com.nimbusds.jwt.proc.DefaultJWTProcessor;
 import com.nimbusds.jwt.proc.JWTProcessor;
-import io.gravitee.gateway.reactive.api.context.HttpExecutionContext;
+import io.gravitee.gateway.reactive.api.context.base.BaseExecutionContext;
 import io.gravitee.policy.jwt.alg.Signature;
 import io.gravitee.policy.jwt.configuration.JWTPolicyConfiguration;
 import io.gravitee.policy.jwt.jwk.AbstractJWKTest;
@@ -63,7 +63,7 @@ class JwksUrlJWTProcessorProviderTest extends AbstractJWKTest {
     private JWTPolicyConfiguration configuration;
 
     @Mock
-    private HttpExecutionContext ctx;
+    private BaseExecutionContext ctx;
 
     @Mock
     private ResourceRetriever resourceRetriever;

--- a/src/test/java/io/gravitee/policy/v3/jwt/JWTPolicyV3Test.java
+++ b/src/test/java/io/gravitee/policy/v3/jwt/JWTPolicyV3Test.java
@@ -140,7 +140,6 @@ public abstract class JWTPolicyV3Test {
     @Test
     void test_unsigned_jwt() throws Exception {
         when(executionContext.getComponent(Environment.class)).thenReturn(environment);
-        when(environment.getProperty("policy.jwt.issuer.gravitee.authorization.server.MAIN")).thenReturn(getSignatureKey());
 
         JWTClaimsSet.Builder builder = getJsonWebTokenBuilder(7200);
         builder.claim(JWTPolicyV3.CONTEXT_ATTRIBUTE_CLIENT_ID, "my-client-id");


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/APIM-7143

**Description**

- use new HttpSecurityPolicy and BaseExecutionContext interface (BREAKING CHANGE: requires APIM 4.6+)
- implement kafka policy
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `6.0.0-apim-7143-impl-security-chain-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/policy/gravitee-policy-jwt/6.0.0-apim-7143-impl-security-chain-SNAPSHOT/gravitee-policy-jwt-6.0.0-apim-7143-impl-security-chain-SNAPSHOT.zip)
  <!-- Version placeholder end -->
