### PR TITLE
feat: add option to follow http redirects

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -54,6 +54,9 @@ Both the header and payload are encoded with Base64, so anyone can read the cont
 
 |publicKeyResolver|X|Used to resolve the public key needed to validate the signature|enum|GIVEN_KEY
 |resolverParameter||Needed if you use the `GATEWAY_KEYS` or `GIVEN_ISSUER` resolver (EL support)|string|
+|connectTimeout||Max time to connect to the JWKS url (only useful when resolver is `JWKS_URL`)|integer|2000
+|requestTimeout||Max time to fetch the JWKS url (only useful when resolver is `JWKS_URL`)|integer|2000
+|followRedirects||Select this option if you want to automatically follow redirect (301, 302) when fecthing the JWKS (only useful when resolver is `JWKS_URL`)|boolean|false
 |useSystemProxy||Select this option if you want use system proxy (only useful when resolver is `JWKS_URL`)|boolean|false
 |extractClaims||Select this option if you want to extract claims into the request context|boolean|false
 |clientIdClaim||Required if the client_id should be read from non-standard claims (azp, aud, client_id)|string|

--- a/src/main/java/io/gravitee/policy/jwt/configuration/JWTPolicyConfiguration.java
+++ b/src/main/java/io/gravitee/policy/jwt/configuration/JWTPolicyConfiguration.java
@@ -46,6 +46,7 @@ public class JWTPolicyConfiguration implements PolicyConfiguration {
     private boolean useSystemProxy;
     private Integer connectTimeout = 2000;
     private Long requestTimeout = 2000L;
+    private Boolean followRedirects = false;
     private ConfirmationMethodValidation confirmationMethodValidation = new ConfirmationMethodValidation();
     private TokenTypValidation tokenTypValidation = new TokenTypValidation();
 

--- a/src/main/java/io/gravitee/policy/jwt/jwk/provider/JwksUrlJWTProcessorProvider.java
+++ b/src/main/java/io/gravitee/policy/jwt/jwk/provider/JwksUrlJWTProcessorProvider.java
@@ -99,6 +99,7 @@ class JwksUrlJWTProcessorProvider implements JWTProcessorProvider {
                         .connectTimeout(configuration.getConnectTimeout())
                         .requestTimeout(configuration.getRequestTimeout())
                         .useSystemProxy(configuration.isUseSystemProxy())
+                        .followRedirects(configuration.getFollowRedirects())
                         .build()
                 );
         }

--- a/src/main/java/io/gravitee/policy/jwt/jwk/source/VertxResourceRetriever.java
+++ b/src/main/java/io/gravitee/policy/jwt/jwk/source/VertxResourceRetriever.java
@@ -47,6 +47,7 @@ public class VertxResourceRetriever implements ResourceRetriever {
 
     private final int connectTimeout;
     private final long requestTimeout;
+    private final boolean followRedirects;
 
     public VertxResourceRetriever(final Vertx vertx, Configuration configuration, RetrieveOptions options) {
         this.vertx = vertx;
@@ -54,6 +55,7 @@ public class VertxResourceRetriever implements ResourceRetriever {
         this.useSystemProxy = options.isUseSystemProxy();
         this.connectTimeout = options.getConnectTimeout();
         this.requestTimeout = options.getRequestTimeout();
+        this.followRedirects = options.isFollowRedirects();
     }
 
     public Single<Resource> retrieve(String url) {
@@ -70,7 +72,8 @@ public class VertxResourceRetriever implements ResourceRetriever {
         final RequestOptions requestOptions = new RequestOptions()
             .setMethod(HttpMethod.GET)
             .setAbsoluteURI(finalURL)
-            .setTimeout(requestTimeout);
+            .setTimeout(requestTimeout)
+            .setFollowRedirects(followRedirects);
 
         return httpClient
             .rxRequest(requestOptions)

--- a/src/main/java/io/gravitee/policy/v3/jwt/jwks/retriever/RetrieveOptions.java
+++ b/src/main/java/io/gravitee/policy/v3/jwt/jwks/retriever/RetrieveOptions.java
@@ -33,6 +33,7 @@ public class RetrieveOptions {
     boolean useSystemProxy;
     Integer connectTimeout;
     Long requestTimeout;
+    boolean followRedirects;
 
     public int getConnectTimeout() {
         return Optional.ofNullable(connectTimeout).orElse(DEFAULT_CONNECT_TIMEOUT);

--- a/src/main/java/io/gravitee/policy/v3/jwt/jwks/retriever/VertxResourceRetriever.java
+++ b/src/main/java/io/gravitee/policy/v3/jwt/jwks/retriever/VertxResourceRetriever.java
@@ -48,6 +48,7 @@ public class VertxResourceRetriever implements ResourceRetriever {
 
     private final int connectTimeout;
     private final long requestTimeout;
+    private final boolean followRedirects;
 
     public VertxResourceRetriever(final Vertx vertx, Configuration configuration, RetrieveOptions options) {
         this.vertx = vertx;
@@ -55,6 +56,7 @@ public class VertxResourceRetriever implements ResourceRetriever {
         this.useSystemProxy = options.isUseSystemProxy();
         this.connectTimeout = options.getConnectTimeout();
         this.requestTimeout = options.getRequestTimeout();
+        this.followRedirects = options.isFollowRedirects();
     }
 
     @Override
@@ -85,7 +87,8 @@ public class VertxResourceRetriever implements ResourceRetriever {
         final RequestOptions requestOptions = new RequestOptions()
             .setMethod(HttpMethod.GET)
             .setAbsoluteURI(url.toString())
-            .setTimeout(requestTimeout);
+            .setTimeout(requestTimeout)
+            .setFollowRedirects(followRedirects);
 
         final Future<HttpClientRequest> futureRequest = httpClient.request(requestOptions);
 

--- a/src/main/resources/schemas/schema-form.json
+++ b/src/main/resources/schemas/schema-form.json
@@ -70,6 +70,12 @@
             "type": "integer",
             "default": 2000
         },
+        "followRedirects": {
+            "title": "Follow HTTP redirects",
+            "description": "Only applies when the resolver is JWKS_URL",
+            "type": "boolean",
+            "default": false
+        },
         "useSystemProxy": {
             "title": "Use system proxy",
             "description": "Use system proxy (make sense only when resolver is set to JWKS_URL)",

--- a/src/test/java/io/gravitee/policy/jwt/jwk/source/VertxResourceRetrieverTest.java
+++ b/src/test/java/io/gravitee/policy/jwt/jwk/source/VertxResourceRetrieverTest.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.policy.jwt.jwk.source;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.*;
+
+import com.github.tomakehurst.wiremock.junit5.WireMockRuntimeInfo;
+import com.github.tomakehurst.wiremock.junit5.WireMockTest;
+import io.gravitee.node.api.configuration.Configuration;
+import io.gravitee.policy.v3.jwt.jwks.retriever.RetrieveOptions;
+import io.vertx.rxjava3.core.Vertx;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.Mock;
+
+/**
+ * @author Jeoffrey HAEYAERT (jeoffrey.haeyaert at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+@WireMockTest
+class VertxResourceRetrieverTest {
+
+    public static final String JWKS_JSON =
+        """
+                      {
+                        "keys" : [ {
+                          "kty" : "RSA",
+                          "use" : "sig",
+                          "alg" : "RS256",
+                          "kid" : "default",
+                          "x5c" : [ "MIICvzCCA..." ],
+                          "x5t#S256" : "_0VtTmrWiO...",
+                          "e" : "AQAB",
+                          "n" : "g4ygRnkRBwPHmHNP8..."
+                        } ]
+                      }
+                    """;
+
+    @Mock
+    private Configuration configuration;
+
+    @Test
+    void should_fetch_resource(WireMockRuntimeInfo wmRuntimeInfo) {
+        stubFor(get(urlPathEqualTo("/.well-known/jwks.json")).willReturn(okJson(JWKS_JSON)));
+
+        VertxResourceRetriever vertxResourceRetriever = new VertxResourceRetriever(
+            Vertx.vertx(),
+            configuration,
+            RetrieveOptions.builder().build()
+        );
+
+        vertxResourceRetriever
+            .retrieve(wmRuntimeInfo.getHttpBaseUrl() + "/.well-known/jwks.json")
+            .test()
+            .awaitDone(10, TimeUnit.SECONDS)
+            .assertValue(resource -> resource.getContent().equals(JWKS_JSON));
+
+        verify(getRequestedFor(urlPathEqualTo("/.well-known/jwks.json")));
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = { true, false })
+    void should_follow_http_temporary_redirects(boolean permanent, WireMockRuntimeInfo wmRuntimeInfo) {
+        stubFor(
+            get(urlPathEqualTo("/.well-known/old-jwks.json"))
+                .willReturn(permanent ? permanentRedirect("/.well-known/jwks.json") : temporaryRedirect("/.well-known/jwks.json"))
+        );
+        stubFor(get(urlPathEqualTo("/.well-known/jwks.json")).willReturn(okJson(JWKS_JSON)));
+
+        VertxResourceRetriever vertxResourceRetriever = new VertxResourceRetriever(
+            Vertx.vertx(),
+            configuration,
+            RetrieveOptions.builder().followRedirects(true).build()
+        );
+
+        vertxResourceRetriever
+            .retrieve(wmRuntimeInfo.getHttpBaseUrl() + "/.well-known/old-jwks.json")
+            .test()
+            .awaitDone(10, TimeUnit.SECONDS)
+            .assertValue(resource -> resource.getContent().equals(JWKS_JSON));
+
+        verify(getRequestedFor(urlPathEqualTo("/.well-known/old-jwks.json")));
+        verify(getRequestedFor(urlPathEqualTo("/.well-known/jwks.json")));
+    }
+}

--- a/src/test/java/io/gravitee/policy/v3/jwt/jwks/retriever/VertxResourceRetrieverTest.java
+++ b/src/test/java/io/gravitee/policy/v3/jwt/jwks/retriever/VertxResourceRetrieverTest.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.policy.v3.jwt.jwks.retriever;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.*;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.github.tomakehurst.wiremock.junit5.WireMockRuntimeInfo;
+import com.github.tomakehurst.wiremock.junit5.WireMockTest;
+import com.nimbusds.jose.util.Resource;
+import io.gravitee.node.api.configuration.Configuration;
+import io.vertx.core.Vertx;
+import java.net.URL;
+import java.util.concurrent.TimeUnit;
+import lombok.SneakyThrows;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.Mock;
+
+/**
+ * @author Jeoffrey HAEYAERT (jeoffrey.haeyaert at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+@WireMockTest
+class VertxResourceRetrieverTest {
+
+    public static final String JWKS_JSON =
+        """
+                      {
+                        "keys" : [ {
+                          "kty" : "RSA",
+                          "use" : "sig",
+                          "alg" : "RS256",
+                          "kid" : "default",
+                          "x5c" : [ "MIICvzCCA..." ],
+                          "x5t#S256" : "_0VtTmrWiO...",
+                          "e" : "AQAB",
+                          "n" : "g4ygRnkRBwPHmHNP8..."
+                        } ]
+                      }
+                    """;
+
+    @Mock
+    private Configuration configuration;
+
+    @Test
+    @SneakyThrows
+    void should_fetch_resource(WireMockRuntimeInfo wmRuntimeInfo) {
+        stubFor(get(urlPathEqualTo("/.well-known/jwks.json")).willReturn(okJson(JWKS_JSON)));
+
+        VertxResourceRetriever vertxResourceRetriever = new VertxResourceRetriever(
+            Vertx.vertx(),
+            configuration,
+            RetrieveOptions.builder().build()
+        );
+
+        Resource resource = vertxResourceRetriever
+            .retrieve(new URL(wmRuntimeInfo.getHttpBaseUrl() + "/.well-known/jwks.json"))
+            .get(10, TimeUnit.SECONDS);
+        assertThat(resource).isNotNull();
+        assertThat(resource.getContent()).isEqualTo(JWKS_JSON);
+
+        verify(getRequestedFor(urlPathEqualTo("/.well-known/jwks.json")));
+    }
+
+    @SneakyThrows
+    @ParameterizedTest
+    @ValueSource(booleans = { true, false })
+    void should_follow_http_temporary_redirects(boolean permanent, WireMockRuntimeInfo wmRuntimeInfo) {
+        stubFor(
+            get(urlPathEqualTo("/.well-known/old-jwks.json"))
+                .willReturn(permanent ? permanentRedirect("/.well-known/jwks.json") : temporaryRedirect("/.well-known/jwks.json"))
+        );
+        stubFor(get(urlPathEqualTo("/.well-known/jwks.json")).willReturn(okJson(JWKS_JSON)));
+
+        VertxResourceRetriever vertxResourceRetriever = new VertxResourceRetriever(
+            Vertx.vertx(),
+            configuration,
+            RetrieveOptions.builder().followRedirects(true).build()
+        );
+
+        Resource resource = vertxResourceRetriever
+            .retrieve(new URL(wmRuntimeInfo.getHttpBaseUrl() + "/.well-known/old-jwks.json"))
+            .get(10, TimeUnit.SECONDS);
+        assertThat(resource).isNotNull();
+        assertThat(resource.getContent()).isEqualTo(JWKS_JSON);
+
+        verify(getRequestedFor(urlPathEqualTo("/.well-known/old-jwks.json")));
+        verify(getRequestedFor(urlPathEqualTo("/.well-known/jwks.json")));
+    }
+}


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-8921

## Description

This PR brings the capability to follow HTTP redirects when fetching remote JWKS.
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `6.1.0-apim-8921-support-follow-http-redirects-fetching-jwks-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/policy/gravitee-policy-jwt/6.1.0-apim-8921-support-follow-http-redirects-fetching-jwks-SNAPSHOT/gravitee-policy-jwt-6.1.0-apim-8921-support-follow-http-redirects-fetching-jwks-SNAPSHOT.zip)
  <!-- Version placeholder end -->
