### PR TITLE
fix: Properly resolve property value

### DIFF
--- a/src/main/java/io/gravitee/policy/jwt/jwk/provider/GatewayKeysJWTProcessorProvider.java
+++ b/src/main/java/io/gravitee/policy/jwt/jwk/provider/GatewayKeysJWTProcessorProvider.java
@@ -90,15 +90,16 @@ class GatewayKeysJWTProcessorProvider implements JWTProcessorProvider {
     private Map<String, List<JWK>> loadFromConfiguration(JWSAlgorithm alg, ConfigurableEnvironment environment) {
         return EnvironmentUtils
             .getPropertiesStartingWith(environment, KEY_PROPERTY_PREFIX)
-            .entrySet()
+            .keySet()
             .stream()
             .map(entry -> {
-                final Matcher matcher = KEY_PROPERTY_PATTERN.matcher(entry.getKey());
+                final Matcher matcher = KEY_PROPERTY_PATTERN.matcher(entry);
 
                 if (matcher.matches()) {
                     final String iss = matcher.group("iss");
                     final String kid = matcher.group("kid");
-                    final String key = (String) entry.getValue();
+                    // getProperty ensure that environment variable are considered during property resolution
+                    final String key = environment.getProperty(entry);
 
                     try {
                         return new SimpleEntry<>(iss, JWKBuilder.buildKey(kid, key, alg));


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-8036

## Description

Force property resolution by using the getProperty method to ensure that environment variables are considered.
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `5.2.1-resolve-gateway-keys-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/policy/gravitee-policy-jwt/5.2.1-resolve-gateway-keys-SNAPSHOT/gravitee-policy-jwt-5.2.1-resolve-gateway-keys-SNAPSHOT.zip)
  <!-- Version placeholder end -->
