### PR TITLE
fix: Properly resolve property value

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ version: 2.1
 setup: true
 
 orbs:
-    gravitee: gravitee-io/gravitee@4.1.1
+    gravitee: gravitee-io/gravitee@4.12.1
 
 # our single workflow, that triggers the setup job defined above, filters on tag and branches are needed otherwise
 # some workflow and job will not be triggered for tags (default CircleCI behavior)

--- a/pom.xml
+++ b/pom.xml
@@ -39,7 +39,7 @@
         <gravitee-policy-api.version>1.11.0</gravitee-policy-api.version>
         <gravitee-node.version>3.1.0</gravitee-node.version>
         <gravitee-common.version>3.3.3</gravitee-common.version>
-        <gravitee-apim.version>4.1.0-SNAPSHOT</gravitee-apim.version>
+        <gravitee-apim.version>4.1.26</gravitee-apim.version>
 
         <nimbus-jose-jwt.version>9.15.2</nimbus-jose-jwt.version>
         <sshj.version>0.35.0</sshj.version>

--- a/src/main/java/io/gravitee/policy/jwt/jwk/provider/GatewayKeysJWTProcessorProvider.java
+++ b/src/main/java/io/gravitee/policy/jwt/jwk/provider/GatewayKeysJWTProcessorProvider.java
@@ -87,15 +87,16 @@ class GatewayKeysJWTProcessorProvider implements JWTProcessorProvider {
     private Map<String, List<JWK>> loadFromConfiguration(JWSAlgorithm alg, ConfigurableEnvironment environment) {
         return EnvironmentUtils
             .getPropertiesStartingWith(environment, KEY_PROPERTY_PREFIX)
-            .entrySet()
+            .keySet()
             .stream()
             .map(entry -> {
-                final Matcher matcher = KEY_PROPERTY_PATTERN.matcher(entry.getKey());
+                final Matcher matcher = KEY_PROPERTY_PATTERN.matcher(entry);
 
                 if (matcher.matches()) {
                     final String iss = matcher.group("iss");
                     final String kid = matcher.group("kid");
-                    final String key = (String) entry.getValue();
+                    // getProperty ensure that environment variable are considered during property resolution
+                    final String key = environment.getProperty(entry);
 
                     try {
                         return new SimpleEntry<>(iss, JWKBuilder.buildKey(kid, key, alg));

--- a/src/test/java/io/gravitee/policy/jwt/jwk/AbstractJWKTest.java
+++ b/src/test/java/io/gravitee/policy/jwt/jwk/AbstractJWKTest.java
@@ -36,8 +36,8 @@ import java.util.Base64;
 import java.util.Date;
 import java.util.stream.Stream;
 import net.schmizz.sshj.common.Buffer;
-import org.apache.commons.lang3.RandomStringUtils;
 import org.junit.jupiter.params.provider.Arguments;
+import wiremock.org.apache.commons.lang3.RandomStringUtils;
 
 /**
  * @author Jeoffrey HAEYAERT (jeoffrey.haeyaert at graviteesource.com)


### PR DESCRIPTION
APIM-8036

## Issue

https://gravitee.atlassian.net/browse/APIM-8036

## Description

Force property resolution by using the getProperty method to ensure that environment variables are considered.

## Additional context
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `4.2.1-APIM-8036-resolve-gateway-keys4-2-x-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/policy/gravitee-policy-jwt/4.2.1-APIM-8036-resolve-gateway-keys4-2-x-SNAPSHOT/gravitee-policy-jwt-4.2.1-APIM-8036-resolve-gateway-keys4-2-x-SNAPSHOT.zip)
  <!-- Version placeholder end -->
