### PR TITLE
fix: Properly resolve property value

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ version: 2.1
 setup: true
 
 orbs:
-    gravitee: gravitee-io/gravitee@4.1.1
+    gravitee: gravitee-io/gravitee@4.12.1
 
 # our single workflow, that triggers the setup job defined above, filters on tag and branches are needed otherwise
 # some workflow and job will not be triggered for tags (default CircleCI behavior)

--- a/src/main/java/io/gravitee/policy/jwt/jwk/provider/GatewayKeysJWTProcessorProvider.java
+++ b/src/main/java/io/gravitee/policy/jwt/jwk/provider/GatewayKeysJWTProcessorProvider.java
@@ -87,15 +87,16 @@ class GatewayKeysJWTProcessorProvider implements JWTProcessorProvider {
     private Map<String, List<JWK>> loadFromConfiguration(JWSAlgorithm alg, ConfigurableEnvironment environment) {
         return EnvironmentUtils
             .getPropertiesStartingWith(environment, KEY_PROPERTY_PREFIX)
-            .entrySet()
+            .keySet()
             .stream()
             .map(entry -> {
-                final Matcher matcher = KEY_PROPERTY_PATTERN.matcher(entry.getKey());
+                final Matcher matcher = KEY_PROPERTY_PATTERN.matcher(entry);
 
                 if (matcher.matches()) {
                     final String iss = matcher.group("iss");
                     final String kid = matcher.group("kid");
-                    final String key = (String) entry.getValue();
+                    // getProperty ensure that environment variable are considered during property resolution
+                    final String key = environment.getProperty(entry);
 
                     try {
                         return new SimpleEntry<>(iss, JWKBuilder.buildKey(kid, key, alg));


### PR DESCRIPTION
APIM-8036

## Issue

https://gravitee.atlassian.net/browse/APIM-8036

## Description

Force property resolution by using the getProperty method to ensure that environment variables are considered.

## Additional context
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `5.1.1-APIM-8036-resolve-gateway-keys5-1-x-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/policy/gravitee-policy-jwt/5.1.1-APIM-8036-resolve-gateway-keys5-1-x-SNAPSHOT/gravitee-policy-jwt-5.1.1-APIM-8036-resolve-gateway-keys5-1-x-SNAPSHOT.zip)
  <!-- Version placeholder end -->
