### PR TITLE
fix: follow http redirect on v2 api

### DIFF
--- a/src/main/java/io/gravitee/policy/v3/jwt/JWTPolicyV3.java
+++ b/src/main/java/io/gravitee/policy/v3/jwt/JWTPolicyV3.java
@@ -295,6 +295,7 @@ public class JWTPolicyV3 {
                                 .connectTimeout(configuration.getConnectTimeout())
                                 .requestTimeout(configuration.getRequestTimeout())
                                 .useSystemProxy(configuration.isUseSystemProxy())
+                                .followRedirects(configuration.getFollowRedirects())
                                 .build()
                         )
                     )


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-9171

## Description

Make sure that the followHttpRedirects option is taken into account for v2 API.
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `6.1.2-apim-9171-fix-follow-redirects-on-v2-apis-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/policy/gravitee-policy-jwt/6.1.2-apim-9171-fix-follow-redirects-on-v2-apis-SNAPSHOT/gravitee-policy-jwt-6.1.2-apim-9171-fix-follow-redirects-on-v2-apis-SNAPSHOT.zip)
  <!-- Version placeholder end -->
