### PR TITLE
fix: calculate right maxLifeTime for kafka oauthbearer

### DIFF
--- a/src/main/java/io/gravitee/policy/jwt/JWTPolicy.java
+++ b/src/main/java/io/gravitee/policy/jwt/JWTPolicy.java
@@ -136,11 +136,9 @@ public class JWTPolicy extends JWTPolicyV3 implements HttpSecurityPolicy, KafkaS
                             Date issueTime = jwtClaimsSet.getIssueTime();
 
                             Environment environment = ctx.getComponent(Environment.class);
-                            long maxTokenLifetime = environment.getProperty(
-                                KAFKA_OAUTHBEARER_MAX_TOKEN_LIFETIME,
-                                Long.class,
-                                DEFAULT_MAX_TOKEN_LIFETIME_MS
-                            );
+                            long maxTokenLifetime =
+                                System.currentTimeMillis() +
+                                environment.getProperty(KAFKA_OAUTHBEARER_MAX_TOKEN_LIFETIME, Long.class, DEFAULT_MAX_TOKEN_LIFETIME_MS);
 
                             OAuthBearerToken token = new BasicOAuthBearerToken(
                                 extractedToken,


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-9349

## Description

This PR fixes the maxLifeTime set on the Kafka oauth bearer token that prevents the Kafka Client from properly re-authenticate before its token expires.