### PR TITLE
fix: condition `.metrics()` use only if ctx is http

### DIFF
--- a/src/main/java/io/gravitee/policy/jwt/JWTPolicy.java
+++ b/src/main/java/io/gravitee/policy/jwt/JWTPolicy.java
@@ -290,12 +290,12 @@ public class JWTPolicy extends JWTPolicyV3 implements HttpSecurityPolicy, KafkaS
     private void reportError(BaseExecutionContext ctx, Throwable throwable) {
         if (throwable != null) {
             if (ctx instanceof HttpPlainExecutionContext httpPlainExecutionContext) {
-                ctx.metrics().setErrorMessage(throwable.getMessage());
+                httpPlainExecutionContext.metrics().setErrorMessage(throwable.getMessage());
 
                 if (log.isDebugEnabled()) {
                     try {
                         final HttpPlainRequest request = httpPlainExecutionContext.request();
-                        final String api = ctx.getAttribute(ATTR_API);
+                        final String api = httpPlainExecutionContext.getAttribute(ATTR_API);
                         MDC.put("api", api);
 
                         log.debug(


### PR DESCRIPTION
## Issue

n/a

## Description



## Additional context
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `6.1.4-refactor-context-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/policy/gravitee-policy-jwt/6.1.4-refactor-context-SNAPSHOT/gravitee-policy-jwt-6.1.4-refactor-context-SNAPSHOT.zip)
  <!-- Version placeholder end -->
