### PR TITLE
fix: Add support for trust_all

### DIFF
--- a/src/main/java/io/gravitee/policy/jwt/jwk/source/VertxResourceRetriever.java
+++ b/src/main/java/io/gravitee/policy/jwt/jwk/source/VertxResourceRetriever.java
@@ -105,7 +105,7 @@ public class VertxResourceRetriever implements ResourceRetriever {
         }
 
         if (HTTPS_SCHEME.equalsIgnoreCase(url.getProtocol())) {
-            options.setSsl(true);
+            options.setSsl(true).setTrustAll(true);
         }
 
         return vertx.createHttpClient(options);


### PR DESCRIPTION
## Description

The JWKS retriever is configured to allow trust_all support for HTTPS URL.
This was the behavior for v2 APIs which has not been migrated to v4 APIs.
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `6.1.5-trust-all-support-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/policy/gravitee-policy-jwt/6.1.5-trust-all-support-SNAPSHOT/gravitee-policy-jwt-6.1.5-trust-all-support-SNAPSHOT.zip)
  <!-- Version placeholder end -->
