### PR TITLE
Revert "fix(jwt): support WWW-Authenticate header"

### DIFF
--- a/src/main/java/io/gravitee/policy/jwt/JWTPolicy.java
+++ b/src/main/java/io/gravitee/policy/jwt/JWTPolicy.java
@@ -68,8 +68,6 @@ public class JWTPolicy extends JWTPolicyV3 implements HttpSecurityPolicy, KafkaS
     private static final Logger log = LoggerFactory.getLogger(JWTPolicy.class);
 
     private final JWTProcessorProvider jwtProcessorResolver;
-    private static final String WWW_AUTHENTICATE_ERROR_INVALID_TOKEN = "invalid_token";
-    static final String ERROR_MSG_INVALID_TOKEN = "Invalid JWT token";
 
     public JWTPolicy(JWTPolicyConfiguration configuration) {
         super(configuration);
@@ -164,7 +162,7 @@ public class JWTPolicy extends JWTPolicyV3 implements HttpSecurityPolicy, KafkaS
                 Callback[] callbacks = ctx.callbacks();
                 for (Callback callback : callbacks) {
                     if (callback instanceof OAuthBearerValidatorCallback oauthCallback) {
-                        oauthCallback.error(WWW_AUTHENTICATE_ERROR_INVALID_TOKEN, null, null);
+                        oauthCallback.error("invalid_token", null, null);
                     }
                 }
 
@@ -217,12 +215,6 @@ public class JWTPolicy extends JWTPolicyV3 implements HttpSecurityPolicy, KafkaS
             return interruptUnauthorized(ctx, JWT_INVALID_TOKEN_KEY);
         }
         return Single.just(new LazyJWT(token.get()));
-    }
-
-    private void setWwwAuthenticateHeaderIfPossible(HttpPlainExecutionContext ctx, String key, Throwable cause) {
-        if (configuration.isSendWwwAuthenticateHeader() && ctx != null && ctx.response() != null && ctx.response().headers() != null) {
-            ctx.response().headers().set(WWW_AUTHENTICATE_HEADER, buildWwwAuthenticateValue(key, cause));
-        }
     }
 
     private Single<JWTClaimsSet> validateToken(BaseExecutionContext ctx, LazyJWT jwt) {

--- a/src/main/java/io/gravitee/policy/jwt/configuration/JWTPolicyConfiguration.java
+++ b/src/main/java/io/gravitee/policy/jwt/configuration/JWTPolicyConfiguration.java
@@ -41,7 +41,6 @@ public class JWTPolicyConfiguration implements PolicyConfiguration {
     private Signature signature;
     private boolean extractClaims = false;
     private boolean propagateAuthHeader = true;
-    private boolean sendWwwAuthenticateHeader = false;
     private String userClaim;
     private String clientIdClaim;
     private boolean useSystemProxy;

--- a/src/main/java/io/gravitee/policy/v3/jwt/JWTPolicyV3.java
+++ b/src/main/java/io/gravitee/policy/v3/jwt/JWTPolicyV3.java
@@ -89,10 +89,6 @@ public class JWTPolicyV3 {
     public static final String JWT_INVALID_CERTIFICATE_BOUND_THUMBPRINT = "JWT_INVALID_CERTIFICATE_BOUND_THUMBPRINT";
     public static final String CLAIMS_CNF = "cnf";
     public static final String CLAIMS_CNF_X5T = "x5t#S256";
-    protected static final String WWW_AUTHENTICATE_HEADER = "WWW-Authenticate";
-    protected static final String WWW_AUTHENTICATE_BEARER_VALUE = "Bearer";
-    private static final String WWW_AUTHENTICATE_ERROR_INVALID_REQUEST = "invalid_request";
-    private static final String WWW_AUTHENTICATE_ERROR_INVALID_TOKEN = "invalid_token";
 
     /**
      * Error message format
@@ -149,7 +145,6 @@ public class JWTPolicyV3 {
                                 .setMessage(throwable.getCause() != null ? throwable.getCause().getMessage() : throwable.getMessage());
                         }
                         MDC.remove("api");
-                        setWwwAuthenticateHeaderIfPossible(response, key, throwable);
                         policyChain.failWith(PolicyResult.failure(key, HttpStatusCode.UNAUTHORIZED_401, UNAUTHORIZED_MESSAGE));
                     } else {
                         try {
@@ -198,7 +193,6 @@ public class JWTPolicyV3 {
                 e.getCause()
             );
             MDC.remove("api");
-            setWwwAuthenticateHeaderIfPossible(response, JWT_MISSING_TOKEN_KEY, e);
             policyChain.failWith(PolicyResult.failure(JWT_MISSING_TOKEN_KEY, HttpStatusCode.UNAUTHORIZED_401, UNAUTHORIZED_MESSAGE));
         }
     }
@@ -331,24 +325,6 @@ public class JWTPolicyV3 {
         } catch (ParseException pe) {
             return CompletableFuture.failedFuture(new InvalidTokenException(pe));
         }
-    }
-
-    protected void setWwwAuthenticateHeaderIfPossible(Response response, String key, Throwable cause) {
-        if (configuration.isSendWwwAuthenticateHeader() && response != null && response.headers() != null) {
-            response.headers().set(WWW_AUTHENTICATE_HEADER, buildWwwAuthenticateValue(key, cause));
-        }
-    }
-
-    protected String buildWwwAuthenticateValue(String key, Throwable cause) {
-        final String error = JWT_MISSING_TOKEN_KEY.equals(key)
-            ? WWW_AUTHENTICATE_ERROR_INVALID_REQUEST
-            : WWW_AUTHENTICATE_ERROR_INVALID_TOKEN;
-        final String description = Optional.ofNullable(cause).map(Throwable::getMessage).orElse(UNAUTHORIZED_MESSAGE);
-        return WWW_AUTHENTICATE_BEARER_VALUE + " error=\"" + error + "\", error_description=\"" + escapeHeaderValue(description) + "\"";
-    }
-
-    protected String escapeHeaderValue(String value) {
-        return value.replace("\\", "\\\\").replace("\"", "\\\"");
     }
 
     protected static boolean isValidCertificateThumbprint(

--- a/src/main/resources/schemas/schema-form.json
+++ b/src/main/resources/schemas/schema-form.json
@@ -88,12 +88,6 @@
             "type": "boolean",
             "default": false
         },
-        "sendWwwAuthenticateHeader": {
-            "title": "Send WWW-Authenticate header",
-            "description": "Emit the WWW-Authenticate response header on unauthorized JWT requests.",
-            "type": "boolean",
-            "default": false
-        },
         "propagateAuthHeader": {
             "title": "Propagate Authorization header",
             "description": "Allows to propagate Authorization header to the target endpoints",

--- a/src/test/java/io/gravitee/policy/jwt/JWTPolicyTest.java
+++ b/src/test/java/io/gravitee/policy/jwt/JWTPolicyTest.java
@@ -35,7 +35,6 @@ import static org.mockito.Mockito.argThat;
 import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.isNull;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -52,8 +51,6 @@ import io.gravitee.gateway.api.http.HttpHeaderNames;
 import io.gravitee.gateway.api.http.HttpHeaders;
 import io.gravitee.gateway.reactive.api.context.http.HttpPlainExecutionContext;
 import io.gravitee.gateway.reactive.api.context.http.HttpPlainRequest;
-import io.gravitee.gateway.reactive.api.context.http.HttpPlainResponse;
-import io.gravitee.gateway.reactive.api.context.kafka.KafkaConnectionContext;
 import io.gravitee.gateway.reactive.api.policy.SecurityToken;
 import io.gravitee.policy.jwt.configuration.JWTPolicyConfiguration;
 import io.gravitee.policy.jwt.jwk.provider.DefaultJWTProcessorProvider;
@@ -65,8 +62,6 @@ import java.util.Collections;
 import java.util.Date;
 import java.util.List;
 import java.util.stream.Stream;
-import javax.security.auth.callback.Callback;
-import org.apache.kafka.common.security.oauthbearer.OAuthBearerValidatorCallback;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -115,15 +110,6 @@ class JWTPolicyTest {
 
     @Mock
     private HttpPlainRequest request;
-
-    @Mock
-    private HttpPlainResponse response;
-
-    @Mock
-    private HttpHeaders responseHeaders;
-
-    @Mock
-    private KafkaConnectionContext kafkaCtx;
 
     private JWTPolicy cut;
 
@@ -411,18 +397,6 @@ class JWTPolicyTest {
         final TestObserver<SecurityToken> obs = cut.extractSecurityToken(ctx).test();
 
         obs.assertComplete().assertValueCount(0);
-    }
-
-    @Test
-    void authenticate_shouldSetInvalidTokenErrorOnKafkaCallback_whenJwtValidationFails() {
-        final OAuthBearerValidatorCallback oauthCallback = new OAuthBearerValidatorCallback("invalid-token");
-        when(kafkaCtx.callbacks()).thenReturn(new Callback[] { oauthCallback });
-
-        final TestObserver<Void> obs = cut.authenticate(kafkaCtx).test();
-
-        obs.assertComplete();
-        assertEquals("invalid_token", oauthCallback.errorStatus());
-        verify(kafkaCtx, never()).setAttribute(eq(CONTEXT_ATTRIBUTE_TOKEN), any());
     }
 
     private void verifyMetricsAttributesAndHeaders(Metrics metrics, HttpHeaders headers, String expectedClientId, String expectedSubject) {

--- a/src/test/java/io/gravitee/policy/v3/jwt/JWTPolicyV3Test.java
+++ b/src/test/java/io/gravitee/policy/v3/jwt/JWTPolicyV3Test.java
@@ -70,9 +70,6 @@ public abstract class JWTPolicyV3Test {
     private Response response;
 
     @Mock
-    private HttpHeaders responseHeaders;
-
-    @Mock
     private PolicyChain policyChain;
 
     @Mock
@@ -85,7 +82,6 @@ public abstract class JWTPolicyV3Test {
     void init() {
         lenient().when(request.metrics()).thenReturn(Metrics.on(System.currentTimeMillis()).build());
         lenient().when(configuration.getSignature()).thenReturn(getSignature());
-        lenient().when(response.headers()).thenReturn(responseHeaders);
     }
 
     @Test
@@ -505,33 +501,6 @@ public abstract class JWTPolicyV3Test {
     }
 
     @Test
-    void test_not_authorization_header_sets_www_authenticate_when_enabled() throws Exception {
-        when(configuration.isSendWwwAuthenticateHeader()).thenReturn(true);
-        when(request.headers()).thenReturn(HttpHeaders.create());
-
-        executePolicy(configuration, request, response, executionContext, policyChain);
-
-        verify(responseHeaders, times(1))
-            .set(eq("WWW-Authenticate"), (CharSequence) argThat(value -> value.toString().contains("Bearer error=\"invalid_request\"")));
-        verify(policyChain, times(1))
-            .failWith(
-                argThat(result ->
-                    result.statusCode() == HttpStatusCode.UNAUTHORIZED_401 && JWTPolicyV3.JWT_MISSING_TOKEN_KEY.equals(result.key())
-                )
-            );
-    }
-
-    @Test
-    void test_not_authorization_header_does_not_set_www_authenticate_when_disabled() throws Exception {
-        when(configuration.isSendWwwAuthenticateHeader()).thenReturn(false);
-        when(request.headers()).thenReturn(HttpHeaders.create());
-
-        executePolicy(configuration, request, response, executionContext, policyChain);
-
-        verify(responseHeaders, never()).set(eq("WWW-Authenticate"), anyString());
-    }
-
-    @Test
     void test_with_processing_error() throws Exception {
         when(executionContext.getComponent(Environment.class)).thenReturn(environment);
         when(environment.getProperty("policy.jwt.issuer.gravitee.authorization.server.MAIN")).thenReturn(getSignatureKey());
@@ -556,27 +525,6 @@ public abstract class JWTPolicyV3Test {
                 )
             );
         verify(policyChain, never()).doNext(request, response);
-    }
-
-    @Test
-    void test_invalid_token_sets_www_authenticate_when_enabled() throws Exception {
-        String jwt = getJsonWebToken(7200);
-
-        when(configuration.isSendWwwAuthenticateHeader()).thenReturn(true);
-        when(request.headers())
-            .thenReturn(HttpHeaders.create().set("Authorization", "Bearer " + jwt.substring(0, jwt.lastIndexOf('.') + 1)));
-        when(configuration.getPublicKeyResolver()).thenReturn(KeyResolver.GATEWAY_KEYS);
-
-        executePolicy(configuration, request, response, executionContext, policyChain);
-
-        verify(responseHeaders, times(1))
-            .set(eq("WWW-Authenticate"), (CharSequence) argThat(value -> value.toString().contains("Bearer error=\"invalid_token\"")));
-        verify(policyChain, times(1))
-            .failWith(
-                argThat(result ->
-                    result.statusCode() == HttpStatusCode.UNAUTHORIZED_401 && JWTPolicyV3.JWT_INVALID_TOKEN_KEY.equals(result.key())
-                )
-            );
     }
 
     @Test


### PR DESCRIPTION
Reverts gravitee-io/gravitee-policy-jwt#166
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `6.1.8-revert-166-fix-APIM-13239-on-6-1-x-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/policy/gravitee-policy-jwt/6.1.8-revert-166-fix-APIM-13239-on-6-1-x-SNAPSHOT/gravitee-policy-jwt-6.1.8-revert-166-fix-APIM-13239-on-6-1-x-SNAPSHOT.zip)
  <!-- Version placeholder end -->
