### PR TITLE
fix(jwt): support WWW-Authenticate header

### DIFF
--- a/src/main/java/io/gravitee/policy/jwt/JWTPolicy.java
+++ b/src/main/java/io/gravitee/policy/jwt/JWTPolicy.java
@@ -23,6 +23,7 @@ import static io.gravitee.reporter.api.http.SecurityType.JWT;
 import com.nimbusds.jwt.JWT;
 import com.nimbusds.jwt.JWTClaimsSet;
 import io.gravitee.common.security.jwt.LazyJWT;
+import io.gravitee.gateway.api.http.HttpHeaderNames;
 import io.gravitee.gateway.reactive.api.ExecutionFailure;
 import io.gravitee.gateway.reactive.api.context.base.BaseExecutionContext;
 import io.gravitee.gateway.reactive.api.context.http.HttpPlainExecutionContext;
@@ -276,9 +277,11 @@ public class JWTPolicy extends JWTPolicyV3 implements HttpSecurityPolicy, KafkaS
 
     private <T> Single<T> interruptUnauthorized(BaseExecutionContext ctx, String key) {
         if (ctx instanceof HttpPlainExecutionContext httpPlainExecutionContext) {
+            final String errorMessage = ctx.metrics().getErrorMessage() != null ? ctx.metrics().getErrorMessage() : UNAUTHORIZED_MESSAGE;
             return httpPlainExecutionContext
                 .interruptWith(new ExecutionFailure(UNAUTHORIZED_401).key(key).message(UNAUTHORIZED_MESSAGE))
                 .<T>toMaybe()
+                .doOnComplete(() -> httpPlainExecutionContext.response().headers().set(HttpHeaderNames.WWW_AUTHENTICATE, errorMessage))
                 .toSingle();
         }
         // FIXME: Kafka Gateway - manage interruption with Kafka.

--- a/src/main/java/io/gravitee/policy/v3/jwt/JWTPolicyV3.java
+++ b/src/main/java/io/gravitee/policy/v3/jwt/JWTPolicyV3.java
@@ -25,6 +25,7 @@ import io.gravitee.common.security.CertificateUtils;
 import io.gravitee.gateway.api.ExecutionContext;
 import io.gravitee.gateway.api.Request;
 import io.gravitee.gateway.api.Response;
+import io.gravitee.gateway.api.http.HttpHeaderNames;
 import io.gravitee.node.api.configuration.Configuration;
 import io.gravitee.policy.api.PolicyChain;
 import io.gravitee.policy.api.PolicyResult;
@@ -115,6 +116,10 @@ public class JWTPolicyV3 {
             // 1_ Extract the JWT from HTTP request headers or query-parameters
             final String jwt = TokenExtractor.extract(request);
 
+            if (jwt == null || jwt.isEmpty()) {
+                throw new InvalidTokenException("Missing token");
+            }
+
             // 2_ Validate the token algorithm + signature
             validate(executionContext, jwt)
                 .whenComplete((claims, throwable) -> {
@@ -145,6 +150,10 @@ public class JWTPolicyV3 {
                                 .setMessage(throwable.getCause() != null ? throwable.getCause().getMessage() : throwable.getMessage());
                         }
                         MDC.remove("api");
+                        final String errorMessage = request.metrics().getMessage() != null
+                            ? request.metrics().getMessage()
+                            : UNAUTHORIZED_MESSAGE;
+                        response.headers().set(HttpHeaderNames.WWW_AUTHENTICATE, errorMessage);
                         policyChain.failWith(PolicyResult.failure(key, HttpStatusCode.UNAUTHORIZED_401, UNAUTHORIZED_MESSAGE));
                     } else {
                         try {
@@ -187,12 +196,12 @@ public class JWTPolicyV3 {
                     }
                 });
         } catch (Exception e) {
-            MDC.put("api", String.valueOf(executionContext.getAttribute(ATTR_API)));
-            LOGGER.error(
-                String.format(errorMessageFormat, executionContext.getAttribute(ATTR_API), request.id(), request.path(), e.getMessage()),
-                e.getCause()
-            );
+            final String api = String.valueOf(executionContext.getAttribute(ATTR_API));
+            MDC.put("api", api);
+            LOGGER.error(String.format(errorMessageFormat, api, request.id(), request.path(), e.getMessage()), e.getCause());
             MDC.remove("api");
+            final String errorMessage = request.metrics().getMessage() != null ? request.metrics().getMessage() : UNAUTHORIZED_MESSAGE;
+            response.headers().set(HttpHeaderNames.WWW_AUTHENTICATE, errorMessage);
             policyChain.failWith(PolicyResult.failure(JWT_MISSING_TOKEN_KEY, HttpStatusCode.UNAUTHORIZED_401, UNAUTHORIZED_MESSAGE));
         }
     }

--- a/src/test/java/io/gravitee/policy/jwt/JWTPolicyTest.java
+++ b/src/test/java/io/gravitee/policy/jwt/JWTPolicyTest.java
@@ -51,6 +51,7 @@ import io.gravitee.gateway.api.http.HttpHeaderNames;
 import io.gravitee.gateway.api.http.HttpHeaders;
 import io.gravitee.gateway.reactive.api.context.http.HttpPlainExecutionContext;
 import io.gravitee.gateway.reactive.api.context.http.HttpPlainRequest;
+import io.gravitee.gateway.reactive.api.context.http.HttpPlainResponse;
 import io.gravitee.gateway.reactive.api.policy.SecurityToken;
 import io.gravitee.policy.jwt.configuration.JWTPolicyConfiguration;
 import io.gravitee.policy.jwt.jwk.provider.DefaultJWTProcessorProvider;
@@ -61,6 +62,7 @@ import io.reactivex.rxjava3.observers.TestObserver;
 import java.util.Collections;
 import java.util.Date;
 import java.util.List;
+import java.util.NoSuchElementException;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -229,8 +231,10 @@ class JWTPolicyTest {
     @Test
     void shouldErrorWith401MissingTokenInterruptionWhenNoAuthorizationHeader() {
         final HttpHeaders headers = mock(HttpHeaders.class);
+        final Metrics metrics = mock(Metrics.class);
         when(ctx.request()).thenReturn(request);
         when(request.headers()).thenReturn(headers);
+        when(ctx.metrics()).thenReturn(metrics);
         when(ctx.interruptWith(any())).thenReturn(Completable.error(new RuntimeException(MOCK_EXCEPTION)));
 
         final TestObserver<Void> obs = cut.onRequest(ctx).test();
@@ -253,10 +257,12 @@ class JWTPolicyTest {
     @Test
     void shouldErrorWith401MissingTokenInterruptionWhenNoToken() {
         final HttpHeaders headers = mock(HttpHeaders.class);
+        final Metrics metrics = mock(Metrics.class);
 
         when(headers.getAll(HttpHeaderNames.AUTHORIZATION)).thenReturn(Collections.emptyList());
         when(ctx.request()).thenReturn(request);
         when(request.headers()).thenReturn(headers);
+        when(ctx.metrics()).thenReturn(metrics);
         when(ctx.interruptWith(any())).thenReturn(Completable.error(new RuntimeException(MOCK_EXCEPTION)));
 
         final TestObserver<Void> obs = cut.onRequest(ctx).test();
@@ -279,10 +285,12 @@ class JWTPolicyTest {
     @Test
     void shouldErrorWith401InvaliTokenInterruptionWhenTokenEmpty() {
         final HttpHeaders headers = mock(HttpHeaders.class);
+        final Metrics metrics = mock(Metrics.class);
 
         when(headers.getAll(HttpHeaderNames.AUTHORIZATION)).thenReturn(List.of("Bearer "));
         when(ctx.request()).thenReturn(request);
         when(request.headers()).thenReturn(headers);
+        when(ctx.metrics()).thenReturn(metrics);
         when(ctx.interruptWith(any())).thenReturn(Completable.error(new RuntimeException(MOCK_EXCEPTION)));
 
         final TestObserver<Void> obs = cut.onRequest(ctx).test();
@@ -397,6 +405,46 @@ class JWTPolicyTest {
         final TestObserver<SecurityToken> obs = cut.extractSecurityToken(ctx).test();
 
         obs.assertComplete().assertValueCount(0);
+    }
+
+    @Test
+    void shouldSetWWWAuthenticateHeaderWithDefaultMessageWhenNoMetricsMessage() {
+        final HttpHeaders headers = mock(HttpHeaders.class);
+        final Metrics metrics = mock(Metrics.class);
+        final HttpPlainResponse response = mock(HttpPlainResponse.class);
+        final io.gravitee.gateway.api.http.HttpHeaders responseHeaders = io.gravitee.gateway.api.http.HttpHeaders.create();
+
+        when(ctx.request()).thenReturn(request);
+        when(request.headers()).thenReturn(headers);
+        when(ctx.metrics()).thenReturn(metrics);
+        when(ctx.response()).thenReturn(response);
+        when(response.headers()).thenReturn(responseHeaders);
+        when(ctx.interruptWith(any())).thenReturn(Completable.complete());
+
+        cut.onRequest(ctx).test().assertError(NoSuchElementException.class);
+
+        assertEquals(UNAUTHORIZED_MESSAGE, responseHeaders.get(HttpHeaderNames.WWW_AUTHENTICATE));
+    }
+
+    @Test
+    void shouldSetWWWAuthenticateHeaderWithMetricsErrorMessage() {
+        final HttpHeaders headers = mock(HttpHeaders.class);
+        final Metrics metrics = mock(Metrics.class);
+        final HttpPlainResponse response = mock(HttpPlainResponse.class);
+        final io.gravitee.gateway.api.http.HttpHeaders responseHeaders = io.gravitee.gateway.api.http.HttpHeaders.create();
+        final String customErrorMessage = "Custom error message";
+
+        when(ctx.request()).thenReturn(request);
+        when(request.headers()).thenReturn(headers);
+        when(ctx.metrics()).thenReturn(metrics);
+        when(metrics.getErrorMessage()).thenReturn(customErrorMessage);
+        when(ctx.response()).thenReturn(response);
+        when(response.headers()).thenReturn(responseHeaders);
+        when(ctx.interruptWith(any())).thenReturn(Completable.complete());
+
+        cut.onRequest(ctx).test().assertError(NoSuchElementException.class);
+
+        assertEquals(customErrorMessage, responseHeaders.get(HttpHeaderNames.WWW_AUTHENTICATE));
     }
 
     private void verifyMetricsAttributesAndHeaders(Metrics metrics, HttpHeaders headers, String expectedClientId, String expectedSubject) {

--- a/src/test/java/io/gravitee/policy/v3/jwt/JWTPolicyV3Test.java
+++ b/src/test/java/io/gravitee/policy/v3/jwt/JWTPolicyV3Test.java
@@ -15,6 +15,8 @@
  */
 package io.gravitee.policy.v3.jwt;
 
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.Mockito.*;
 
 import com.nimbusds.jose.JWSHeader;
@@ -553,6 +555,40 @@ public abstract class JWTPolicyV3Test {
         verify(policyChain, never()).doNext(request, response);
     }
 
+    @Test
+    void test_onRequest_WWWAuthenticate_with_default_message() {
+        when(request.headers()).thenReturn(HttpHeaders.create());
+        io.gravitee.gateway.api.http.HttpHeaders responseHeaders = mock(io.gravitee.gateway.api.http.HttpHeaders.class);
+        when(response.headers()).thenReturn(responseHeaders);
+        Metrics metrics = mock(Metrics.class);
+        when(request.metrics()).thenReturn(metrics);
+
+        // Bypass the validate call by providing no token and no key resolver
+        lenient().when(configuration.getPublicKeyResolver()).thenReturn(null);
+
+        new JWTPolicyV3(configuration).onRequest(request, response, executionContext, policyChain);
+
+        verify(responseHeaders).set(io.gravitee.gateway.api.http.HttpHeaderNames.WWW_AUTHENTICATE, JWTPolicyV3.UNAUTHORIZED_MESSAGE);
+    }
+
+    @Test
+    void test_onRequest_WWWAuthenticate_with_custom_message() {
+        when(request.headers()).thenReturn(HttpHeaders.create());
+        io.gravitee.gateway.api.http.HttpHeaders responseHeaders = mock(io.gravitee.gateway.api.http.HttpHeaders.class);
+        when(response.headers()).thenReturn(responseHeaders);
+
+        String customMessage = "Custom error message";
+        Metrics metrics = mock(Metrics.class);
+        when(request.metrics()).thenReturn(metrics);
+        when(metrics.getMessage()).thenReturn(customMessage);
+
+        lenient().when(configuration.getPublicKeyResolver()).thenReturn(null);
+
+        new JWTPolicyV3(configuration).onRequest(request, response, executionContext, policyChain);
+
+        verify(responseHeaders).set(io.gravitee.gateway.api.http.HttpHeaderNames.WWW_AUTHENTICATE, customMessage);
+    }
+
     private void executePolicy(
         JWTPolicyConfiguration configuration,
         Request request,
@@ -561,6 +597,9 @@ public abstract class JWTPolicyV3Test {
         PolicyChain policyChain
     ) throws InterruptedException {
         final CountDownLatch lock = new CountDownLatch(1);
+
+        lenient().when(request.metrics()).thenReturn(mock(Metrics.class));
+        lenient().when(response.headers()).thenReturn(HttpHeaders.create());
 
         new JWTPolicyV3(configuration).onRequest(request, response, executionContext, policyChain);
 


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/XXXXX

## Description

A small description of what you did in that PR.

## Additional context
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `6.1.9-fix-apim-13239-6-1-x-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/policy/gravitee-policy-jwt/6.1.9-fix-apim-13239-6-1-x-SNAPSHOT/gravitee-policy-jwt-6.1.9-fix-apim-13239-6-1-x-SNAPSHOT.zip)
  <!-- Version placeholder end -->
