### PR TITLE
fix(jwt): support WWW-Authenticate header

### DIFF
--- a/src/main/java/io/gravitee/policy/jwt/JWTPolicy.java
+++ b/src/main/java/io/gravitee/policy/jwt/JWTPolicy.java
@@ -25,6 +25,7 @@ import com.nimbusds.jose.proc.BadJOSEException;
 import com.nimbusds.jose.proc.SecurityContext;
 import com.nimbusds.jwt.JWT;
 import com.nimbusds.jwt.JWTClaimsSet;
+import com.nimbusds.jwt.proc.BadJWTException;
 import com.nimbusds.jwt.proc.JWTProcessor;
 import io.gravitee.common.security.jwt.LazyJWT;
 import io.gravitee.gateway.reactive.api.ExecutionFailure;
@@ -52,6 +53,7 @@ import java.text.ParseException;
 import java.util.Date;
 import java.util.Optional;
 import java.util.Set;
+import java.util.StringJoiner;
 import javax.security.auth.callback.Callback;
 import org.apache.kafka.common.security.oauthbearer.OAuthBearerToken;
 import org.apache.kafka.common.security.oauthbearer.OAuthBearerValidatorCallback;
@@ -72,6 +74,9 @@ public class JWTPolicy extends JWTPolicyV3 implements HttpSecurityPolicy, KafkaS
     private static final String KAFKA_OAUTHBEARER_MAX_TOKEN_LIFETIME = "kafka.oauthbearer.maxTokenLifetime";
     private static final long DEFAULT_MAX_TOKEN_LIFETIME_MS = 60 * 60 * 1000L; // 1 hour
     public static final String JWT_REVOKED = "JWT_REVOKED";
+    public static final String JWT_INVALID_CLIENT_ID_KEY = "JWT_INVALID_CLIENT_ID";
+    public static final String JWT_INVALID_CLAIMS_KEY = "JWT_INVALID_CLAIMS";
+    public static final String JWT_EXPIRED_TOKEN_KEY = "JWT_EXPIRED_TOKEN";
 
     private static final Logger log = LoggerFactory.getLogger(JWTPolicy.class);
 
@@ -190,26 +195,51 @@ public class JWTPolicy extends JWTPolicyV3 implements HttpSecurityPolicy, KafkaS
 
         if (jwtToken != null) {
             ctx.setAttribute(CONTEXT_ATTRIBUTE_JWT, jwtToken);
-            String clientId = getClientId(jwtToken);
-            if (clientId != null) {
-                return Maybe.just(SecurityToken.forClientId(clientId));
+            ClientIdExtractionResult extractionResult = extractClientId(jwtToken);
+            if (extractionResult.clientId() != null) {
+                return Maybe.just(SecurityToken.forClientId(extractionResult.clientId()));
+            }
+            if (
+                configuration.isSendWwwAuthenticateHeader() &&
+                extractionResult.errorKey() != null &&
+                ctx instanceof HttpPlainExecutionContext httpPlainExecutionContext
+            ) {
+                addWwwAuthenticateHeader(httpPlainExecutionContext, extractionResult.errorKey());
             }
             return Maybe.just(SecurityToken.invalid(SecurityToken.TokenType.CLIENT_ID));
         }
 
+        if (configuration.isSendWwwAuthenticateHeader() && ctx instanceof HttpPlainExecutionContext httpPlainExecutionContext) {
+            addWwwAuthenticateHeader(httpPlainExecutionContext, JWT_MISSING_TOKEN_KEY);
+        }
         return Maybe.empty();
     }
 
-    private String getClientId(LazyJWT jwtToken) {
+    private ClientIdExtractionResult extractClientId(LazyJWT jwtToken) {
         try {
             JWT jwt = jwtToken.getDelegate();
             if (jwt != null) {
-                return getClientId(jwt.getJWTClaimsSet());
+                String clientId = getClientId(jwt.getJWTClaimsSet());
+                if (clientId != null) {
+                    return ClientIdExtractionResult.success(clientId);
+                }
+                return ClientIdExtractionResult.error(JWT_INVALID_CLIENT_ID_KEY);
             }
-        } catch (ParseException e) {
-            log.error("Failed to parse JWT claim set while looking for clientId", e);
+            return ClientIdExtractionResult.error(JWT_INVALID_TOKEN_KEY);
+        } catch (Exception e) {
+            log.error("Failed to extract clientId from JWT claim set", e);
+            return ClientIdExtractionResult.error(JWT_INVALID_TOKEN_KEY);
         }
-        return null;
+    }
+
+    private record ClientIdExtractionResult(String clientId, String errorKey) {
+        private static ClientIdExtractionResult success(String clientId) {
+            return new ClientIdExtractionResult(clientId, null);
+        }
+
+        private static ClientIdExtractionResult error(String errorKey) {
+            return new ClientIdExtractionResult(null, errorKey);
+        }
     }
 
     private Single<JWTClaimsSet> handleSecurity(final BaseExecutionContext ctx) {
@@ -259,7 +289,7 @@ public class JWTPolicy extends JWTPolicyV3 implements HttpSecurityPolicy, KafkaS
                     jwtClaimsSet = extractJwtClaimsSet(ctx, jwt, jwtProcessor);
                 } catch (Exception exception) {
                     reportError(ctx, exception);
-                    return interruptUnauthorized(ctx, JWT_INVALID_TOKEN_KEY);
+                    return interruptUnauthorized(ctx, resolveUnauthorizedKey(exception));
                 }
 
                 return validateRevocation(ctx, jwtClaimsSet)
@@ -324,6 +354,9 @@ public class JWTPolicy extends JWTPolicyV3 implements HttpSecurityPolicy, KafkaS
 
     private <T> Single<T> interruptUnauthorized(BaseExecutionContext ctx, String key) {
         if (ctx instanceof HttpPlainExecutionContext httpPlainExecutionContext) {
+            if (configuration.isSendWwwAuthenticateHeader()) {
+                addWwwAuthenticateHeader(httpPlainExecutionContext, key);
+            }
             return httpPlainExecutionContext
                 .interruptWith(new ExecutionFailure(UNAUTHORIZED_401).key(key).message(UNAUTHORIZED_MESSAGE))
                 .<T>toMaybe()
@@ -331,6 +364,42 @@ public class JWTPolicy extends JWTPolicyV3 implements HttpSecurityPolicy, KafkaS
         }
         // FIXME: Kafka Gateway - manage interruption with Kafka.
         return Single.error(new Exception(key));
+    }
+
+    private void addWwwAuthenticateHeader(HttpPlainExecutionContext ctx, String key) {
+        String realm = Optional.ofNullable(configuration.getRealm()).filter(r -> !r.isBlank()).orElse("api-gateway");
+
+        StringJoiner headerValue = new StringJoiner(", ");
+        headerValue.add("Bearer realm=\"" + realm + "\"");
+
+        if (!JWT_MISSING_TOKEN_KEY.equals(key)) {
+            headerValue.add("error=\"invalid_token\"");
+            headerValue.add("error_description=\"" + resolveErrorDescription(key) + "\"");
+        }
+
+        ctx.response().headers().set("WWW-Authenticate", headerValue.toString());
+    }
+
+    private static String resolveErrorDescription(String key) {
+        return switch (key) {
+            case JWT_REVOKED -> "The access token has been revoked";
+            case JWT_INVALID_CLIENT_ID_KEY -> "The access token does not contain a valid client_id claim";
+            case JWT_EXPIRED_TOKEN_KEY -> "The access token is expired";
+            case JWT_INVALID_CLAIMS_KEY -> "The access token claims are invalid";
+            case JWT_INVALID_CERTIFICATE_BOUND_THUMBPRINT -> "The access token certificate-bound thumbprint is invalid";
+            default -> "The access token is invalid or expired";
+        };
+    }
+
+    private static String resolveUnauthorizedKey(Throwable throwable) {
+        if (throwable instanceof BadJWTException) {
+            String message = Optional.ofNullable(throwable.getMessage()).orElse("").toLowerCase();
+            if (message.contains("expired")) {
+                return JWT_EXPIRED_TOKEN_KEY;
+            }
+            return JWT_INVALID_CLAIMS_KEY;
+        }
+        return JWT_INVALID_TOKEN_KEY;
     }
 
     private void reportError(BaseExecutionContext ctx, Throwable throwable) {

--- a/src/main/java/io/gravitee/policy/jwt/JWTPolicy.java
+++ b/src/main/java/io/gravitee/policy/jwt/JWTPolicy.java
@@ -25,6 +25,7 @@ import com.nimbusds.jose.proc.BadJOSEException;
 import com.nimbusds.jose.proc.SecurityContext;
 import com.nimbusds.jwt.JWT;
 import com.nimbusds.jwt.JWTClaimsSet;
+import com.nimbusds.jwt.proc.BadJWTException;
 import com.nimbusds.jwt.proc.JWTProcessor;
 import io.gravitee.common.security.jwt.LazyJWT;
 import io.gravitee.gateway.reactive.api.ExecutionFailure;
@@ -71,7 +72,6 @@ public class JWTPolicy extends JWTPolicyV3 implements HttpSecurityPolicy, KafkaS
 
     private static final String KAFKA_OAUTHBEARER_MAX_TOKEN_LIFETIME = "kafka.oauthbearer.maxTokenLifetime";
     private static final long DEFAULT_MAX_TOKEN_LIFETIME_MS = 60 * 60 * 1000L; // 1 hour
-    public static final String JWT_REVOKED = "JWT_REVOKED";
 
     private static final Logger log = LoggerFactory.getLogger(JWTPolicy.class);
 
@@ -134,6 +134,8 @@ public class JWTPolicy extends JWTPolicyV3 implements HttpSecurityPolicy, KafkaS
                     if (!configuration.isPropagateAuthHeader()) {
                         ctx.request().headers().remove(HttpHeaders.AUTHORIZATION);
                     }
+
+                    ctx.response().headers().remove("WWW-Authenticate");
                 })
             );
     }
@@ -190,26 +192,50 @@ public class JWTPolicy extends JWTPolicyV3 implements HttpSecurityPolicy, KafkaS
 
         if (jwtToken != null) {
             ctx.setAttribute(CONTEXT_ATTRIBUTE_JWT, jwtToken);
-            String clientId = getClientId(jwtToken);
-            if (clientId != null) {
-                return Maybe.just(SecurityToken.forClientId(clientId));
+            ClientIdExtractionResult extractionResult = extractClientId(jwtToken);
+            if (extractionResult.clientId() != null) {
+                return Maybe.just(SecurityToken.forClientId(extractionResult.clientId()));
+            }
+            if (extractionResult.errorKey() != null && ctx instanceof HttpPlainExecutionContext httpPlainExecutionContext) {
+                addWwwAuthenticateHeader(httpPlainExecutionContext, extractionResult.errorKey());
             }
             return Maybe.just(SecurityToken.invalid(SecurityToken.TokenType.CLIENT_ID));
         }
 
+        if (ctx instanceof HttpPlainExecutionContext httpPlainExecutionContext) {
+            addWwwAuthenticateHeader(httpPlainExecutionContext, JWT_MISSING_TOKEN_KEY);
+        }
         return Maybe.empty();
     }
 
-    private String getClientId(LazyJWT jwtToken) {
+    private ClientIdExtractionResult extractClientId(LazyJWT jwtToken) {
         try {
             JWT jwt = jwtToken.getDelegate();
             if (jwt != null) {
-                return getClientId(jwt.getJWTClaimsSet());
+                String clientId = getClientId(jwt.getJWTClaimsSet());
+                if (clientId != null) {
+                    return ClientIdExtractionResult.success(clientId);
+                }
+                return ClientIdExtractionResult.error(JWT_INVALID_CLIENT_ID_KEY);
             }
+            return ClientIdExtractionResult.error(JWT_INVALID_TOKEN_KEY);
         } catch (ParseException e) {
             log.error("Failed to parse JWT claim set while looking for clientId", e);
+            return ClientIdExtractionResult.error(JWT_INVALID_TOKEN_KEY);
+        } catch (Exception e) {
+            log.error("Failed to extract clientId from JWT claim set", e);
+            return ClientIdExtractionResult.error(JWT_INVALID_TOKEN_KEY);
         }
-        return null;
+    }
+
+    private record ClientIdExtractionResult(String clientId, String errorKey) {
+        private static ClientIdExtractionResult success(String clientId) {
+            return new ClientIdExtractionResult(clientId, null);
+        }
+
+        private static ClientIdExtractionResult error(String errorKey) {
+            return new ClientIdExtractionResult(null, errorKey);
+        }
     }
 
     private Single<JWTClaimsSet> handleSecurity(final BaseExecutionContext ctx) {
@@ -259,7 +285,7 @@ public class JWTPolicy extends JWTPolicyV3 implements HttpSecurityPolicy, KafkaS
                     jwtClaimsSet = extractJwtClaimsSet(ctx, jwt, jwtProcessor);
                 } catch (Exception exception) {
                     reportError(ctx, exception);
-                    return interruptUnauthorized(ctx, JWT_INVALID_TOKEN_KEY);
+                    return interruptUnauthorized(ctx, resolveReactiveUnauthorizedKey(exception));
                 }
 
                 return validateRevocation(ctx, jwtClaimsSet)
@@ -324,6 +350,7 @@ public class JWTPolicy extends JWTPolicyV3 implements HttpSecurityPolicy, KafkaS
 
     private <T> Single<T> interruptUnauthorized(BaseExecutionContext ctx, String key) {
         if (ctx instanceof HttpPlainExecutionContext httpPlainExecutionContext) {
+            addWwwAuthenticateHeader(httpPlainExecutionContext, key);
             return httpPlainExecutionContext
                 .interruptWith(new ExecutionFailure(UNAUTHORIZED_401).key(key).message(UNAUTHORIZED_MESSAGE))
                 .<T>toMaybe()
@@ -331,6 +358,20 @@ public class JWTPolicy extends JWTPolicyV3 implements HttpSecurityPolicy, KafkaS
         }
         // FIXME: Kafka Gateway - manage interruption with Kafka.
         return Single.error(new Exception(key));
+    }
+
+    private void addWwwAuthenticateHeader(HttpPlainExecutionContext ctx, String key) {
+        ctx.response().headers().set("WWW-Authenticate", buildWwwAuthenticateHeaderValue(key));
+    }
+
+    private static String resolveReactiveUnauthorizedKey(Throwable throwable) {
+        if (throwable instanceof BadJWTException badJwtException && isExpiredJwtMessage(badJwtException.getMessage())) {
+            return JWT_EXPIRED_TOKEN_KEY;
+        }
+        if (throwable instanceof BadJWTException) {
+            return JWT_INVALID_CLAIMS_KEY;
+        }
+        return JWT_INVALID_TOKEN_KEY;
     }
 
     private void reportError(BaseExecutionContext ctx, Throwable throwable) {

--- a/src/main/java/io/gravitee/policy/jwt/configuration/JWTPolicyConfiguration.java
+++ b/src/main/java/io/gravitee/policy/jwt/configuration/JWTPolicyConfiguration.java
@@ -43,6 +43,7 @@ public class JWTPolicyConfiguration implements PolicyConfiguration {
     private boolean propagateAuthHeader = true;
     private String userClaim;
     private String clientIdClaim;
+    private String realm = "api-gateway";
     private boolean useSystemProxy;
     private Integer connectTimeout = 2000;
     private Long requestTimeout = 2000L;

--- a/src/main/java/io/gravitee/policy/jwt/configuration/JWTPolicyConfiguration.java
+++ b/src/main/java/io/gravitee/policy/jwt/configuration/JWTPolicyConfiguration.java
@@ -41,8 +41,10 @@ public class JWTPolicyConfiguration implements PolicyConfiguration {
     private Signature signature;
     private boolean extractClaims = false;
     private boolean propagateAuthHeader = true;
+    private boolean sendWwwAuthenticateHeader = false;
     private String userClaim;
     private String clientIdClaim;
+    private String realm = "api-gateway";
     private boolean useSystemProxy;
     private Integer connectTimeout = 2000;
     private Long requestTimeout = 2000L;

--- a/src/main/java/io/gravitee/policy/v3/jwt/JWTPolicyV3.java
+++ b/src/main/java/io/gravitee/policy/v3/jwt/JWTPolicyV3.java
@@ -56,6 +56,7 @@ import java.security.cert.X509Certificate;
 import java.text.ParseException;
 import java.util.List;
 import java.util.Optional;
+import java.util.StringJoiner;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicReference;
 import javax.net.ssl.SSLSession;
@@ -89,6 +90,15 @@ public class JWTPolicyV3 {
     public static final String JWT_MISSING_TOKEN_KEY = "JWT_MISSING_TOKEN";
     public static final String JWT_INVALID_TOKEN_KEY = "JWT_INVALID_TOKEN";
     public static final String JWT_INVALID_CERTIFICATE_BOUND_THUMBPRINT = "JWT_INVALID_CERTIFICATE_BOUND_THUMBPRINT";
+    public static final String JWT_REVOKED = "JWT_REVOKED";
+    public static final String JWT_INVALID_CLIENT_ID_KEY = "JWT_INVALID_CLIENT_ID";
+    public static final String JWT_UNAUTHORIZED_CLIENT_ID_KEY = "JWT_UNAUTHORIZED_CLIENT_ID";
+    public static final String JWT_INVALID_CLAIMS_KEY = "JWT_INVALID_CLAIMS";
+    public static final String JWT_EXPIRED_TOKEN_KEY = "JWT_EXPIRED_TOKEN";
+    /**
+     * Message of {@link com.nimbusds.jwt.proc.DefaultJWTClaimsVerifier#EXPIRED_JWT_EXCEPTION}.
+     */
+    public static final String EXPIRED_JWT_EXCEPTION_MESSAGE = "Expired JWT";
     public static final String CLAIMS_CNF = "cnf";
     public static final String CLAIMS_CNF_X5T = "x5t#S256";
 
@@ -125,7 +135,7 @@ public class JWTPolicyV3 {
                     final String api = String.valueOf(executionContext.getAttribute(ATTR_API));
                     MDC.put("api", api);
                     if (throwable != null) {
-                        String key = JWT_INVALID_TOKEN_KEY;
+                        String key = resolveUnauthorizedKey(throwable);
                         if (throwable.getCause() instanceof InvalidTokenException) {
                             LOGGER.debug(
                                 String.format(errorMessageFormat, api, request.id(), request.path(), throwable.getMessage()),
@@ -133,7 +143,6 @@ public class JWTPolicyV3 {
                             );
                             request.metrics().setMessage(throwable.getCause().getCause().getMessage());
                         } else if (throwable instanceof InvalidCertificateThumbprintException) {
-                            key = JWT_INVALID_CERTIFICATE_BOUND_THUMBPRINT;
                             LOGGER.debug(
                                 String.format(errorMessageFormat, api, request.id(), request.path(), throwable.getMessage()),
                                 throwable
@@ -149,6 +158,7 @@ public class JWTPolicyV3 {
                                 .setMessage(throwable.getCause() != null ? throwable.getCause().getMessage() : throwable.getMessage());
                         }
                         MDC.remove("api");
+                        setWwwAuthenticateHeader(response, key);
                         policyChain.failWith(PolicyResult.failure(key, HttpStatusCode.UNAUTHORIZED_401, UNAUTHORIZED_MESSAGE));
                     } else {
                         try {
@@ -175,6 +185,10 @@ public class JWTPolicyV3 {
                                 request.headers().remove(HttpHeaders.AUTHORIZATION);
                             }
 
+                            if (response.headers() != null) {
+                                response.headers().remove("WWW-Authenticate");
+                            }
+
                             // Finally continue the process...
                             policyChain.doNext(request, response);
                         } catch (Exception e) {
@@ -182,6 +196,7 @@ public class JWTPolicyV3 {
                                 String.format(errorMessageFormat, api, request.id(), request.path(), e.getMessage()),
                                 e.getCause()
                             );
+                            setWwwAuthenticateHeader(response, JWT_INVALID_TOKEN_KEY);
                             policyChain.failWith(
                                 PolicyResult.failure(JWT_INVALID_TOKEN_KEY, HttpStatusCode.UNAUTHORIZED_401, UNAUTHORIZED_MESSAGE)
                             );
@@ -197,8 +212,61 @@ public class JWTPolicyV3 {
                 e.getCause()
             );
             MDC.remove("api");
+            setWwwAuthenticateHeader(response, JWT_MISSING_TOKEN_KEY);
             policyChain.failWith(PolicyResult.failure(JWT_MISSING_TOKEN_KEY, HttpStatusCode.UNAUTHORIZED_401, UNAUTHORIZED_MESSAGE));
         }
+    }
+
+    protected void setWwwAuthenticateHeader(Response response, String key) {
+        if (response.headers() != null) {
+            response.headers().set("WWW-Authenticate", buildWwwAuthenticateHeaderValue(key));
+        }
+    }
+
+    protected String buildWwwAuthenticateHeaderValue(String key) {
+        String realm = Optional.ofNullable(configuration.getRealm()).filter(r -> !r.isBlank()).orElse("api-gateway");
+
+        StringJoiner headerValue = new StringJoiner(", ");
+        headerValue.add("Bearer realm=\"" + realm + "\"");
+        headerValue.add("error=\"" + (JWT_MISSING_TOKEN_KEY.equals(key) ? "invalid_request" : "invalid_token") + "\"");
+        headerValue.add("error_description=\"" + resolveErrorDescription(key) + "\"");
+
+        return headerValue.toString();
+    }
+
+    protected static String resolveErrorDescription(String key) {
+        return switch (key) {
+            case JWT_MISSING_TOKEN_KEY -> "No access token was provided";
+            case JWT_REVOKED -> "The access token has been revoked";
+            case JWT_INVALID_CLIENT_ID_KEY -> "The access token does not contain a valid client_id claim";
+            case JWT_UNAUTHORIZED_CLIENT_ID_KEY -> "The access token client_id is not authorized";
+            case JWT_EXPIRED_TOKEN_KEY -> "The access token is expired";
+            case JWT_INVALID_CLAIMS_KEY -> "The access token claims are invalid";
+            case JWT_INVALID_CERTIFICATE_BOUND_THUMBPRINT -> "The access token certificate-bound thumbprint is invalid";
+            default -> "The access token is invalid";
+        };
+    }
+
+    protected static boolean isExpiredJwtMessage(String message) {
+        return EXPIRED_JWT_EXCEPTION_MESSAGE.equals(message);
+    }
+
+    protected String resolveUnauthorizedKey(Throwable throwable) {
+        if (throwable instanceof InvalidCertificateThumbprintException) {
+            return JWT_INVALID_CERTIFICATE_BOUND_THUMBPRINT;
+        }
+        Throwable cause = throwable.getCause() != null ? throwable.getCause() : throwable;
+        if (cause instanceof InvalidTokenException invalidTokenException) {
+            Throwable tokenCause = invalidTokenException.getCause();
+            if (tokenCause != null && isExpiredJwtMessage(tokenCause.getMessage())) {
+                return JWT_EXPIRED_TOKEN_KEY;
+            }
+            return JWT_INVALID_CLAIMS_KEY;
+        }
+        if (isExpiredJwtMessage(throwable.getMessage())) {
+            return JWT_EXPIRED_TOKEN_KEY;
+        }
+        return JWT_INVALID_TOKEN_KEY;
     }
 
     protected String getClientId(JWTClaimsSet claims) {

--- a/src/main/resources/schemas/schema-form.json
+++ b/src/main/resources/schemas/schema-form.json
@@ -130,6 +130,12 @@
             "type": "boolean",
             "default": true
         },
+        "sendWwwAuthenticateHeader": {
+            "title": "Send WWW-Authenticate header",
+            "description": "Emit the WWW-Authenticate response header on unauthorized JWT requests.",
+            "type": "boolean",
+            "default": false
+        },
         "userClaim": {
             "title": "User claim",
             "description": "Claim where the user can be extracted",

--- a/src/test/java/io/gravitee/policy/jwt/JWTPolicyTest.java
+++ b/src/test/java/io/gravitee/policy/jwt/JWTPolicyTest.java
@@ -47,6 +47,7 @@ import com.nimbusds.jose.proc.SecurityContext;
 import com.nimbusds.jwt.JWT;
 import com.nimbusds.jwt.JWTClaimNames;
 import com.nimbusds.jwt.JWTClaimsSet;
+import com.nimbusds.jwt.proc.BadJWTException;
 import com.nimbusds.jwt.proc.JWTProcessor;
 import io.gravitee.common.http.HttpStatusCode;
 import io.gravitee.common.security.jwt.LazyJWT;
@@ -54,6 +55,7 @@ import io.gravitee.gateway.api.http.HttpHeaderNames;
 import io.gravitee.gateway.api.http.HttpHeaders;
 import io.gravitee.gateway.reactive.api.context.http.HttpPlainExecutionContext;
 import io.gravitee.gateway.reactive.api.context.http.HttpPlainRequest;
+import io.gravitee.gateway.reactive.api.context.http.HttpPlainResponse;
 import io.gravitee.gateway.reactive.api.policy.SecurityToken;
 import io.gravitee.policy.jwt.configuration.JWTPolicyConfiguration;
 import io.gravitee.policy.jwt.configuration.RevocationCheckConfiguration;
@@ -117,6 +119,9 @@ class JWTPolicyTest {
     private HttpPlainRequest request;
 
     @Mock
+    private HttpPlainResponse response;
+
+    @Mock
     private RevocationChecker revocationChecker;
 
     private JWTPolicy cut;
@@ -132,6 +137,10 @@ class JWTPolicyTest {
     private void prepareClaimsSetCacheMocking() {
         lenient().when(ctx.getAttribute(ATTR_API)).thenReturn("API_ID");
         lenient().when(ctx.getAttribute(CONTEXT_ATTRIBUTE_JWT)).thenReturn(null);
+        lenient().when(configuration.getRealm()).thenReturn("api-gateway");
+        lenient().when(ctx.response()).thenReturn(response);
+        HttpHeaders responseHeaders = mock(HttpHeaders.class);
+        lenient().when(response.headers()).thenReturn(responseHeaders);
     }
 
     private static Stream<Arguments> provideClientIdParameters() {
@@ -298,6 +307,7 @@ class JWTPolicyTest {
         when(revocationCheckConfiguration.isEnabled()).thenReturn(true);
         when(revocationChecker.isRevoked(claimsSet)).thenReturn(true);
         when(ctx.interruptWith(any())).thenReturn(Completable.error(new RuntimeException(MOCK_EXCEPTION)));
+        when(configuration.isSendWwwAuthenticateHeader()).thenReturn(true);
 
         final TestObserver<Void> obs = cut.onRequest(ctx).test();
         obs.assertError(Throwable.class);
@@ -314,6 +324,11 @@ class JWTPolicyTest {
                     return true;
                 })
             );
+        verify(response.headers())
+            .set(
+                "WWW-Authenticate",
+                "Bearer realm=\"api-gateway\", error=\"invalid_token\", error_description=\"The access token has been revoked\""
+            );
     }
 
     @Test
@@ -322,6 +337,7 @@ class JWTPolicyTest {
         when(ctx.request()).thenReturn(request);
         when(request.headers()).thenReturn(headers);
         when(ctx.interruptWith(any())).thenReturn(Completable.error(new RuntimeException(MOCK_EXCEPTION)));
+        when(configuration.isSendWwwAuthenticateHeader()).thenReturn(true);
 
         final TestObserver<Void> obs = cut.onRequest(ctx).test();
         obs.assertError(Throwable.class);
@@ -338,6 +354,7 @@ class JWTPolicyTest {
                     return true;
                 })
             );
+        verify(response.headers()).set("WWW-Authenticate", "Bearer realm=\"api-gateway\"");
     }
 
     @Test
@@ -348,6 +365,7 @@ class JWTPolicyTest {
         when(ctx.request()).thenReturn(request);
         when(request.headers()).thenReturn(headers);
         when(ctx.interruptWith(any())).thenReturn(Completable.error(new RuntimeException(MOCK_EXCEPTION)));
+        when(configuration.isSendWwwAuthenticateHeader()).thenReturn(true);
 
         final TestObserver<Void> obs = cut.onRequest(ctx).test();
         obs.assertError(Throwable.class);
@@ -364,6 +382,7 @@ class JWTPolicyTest {
                     return true;
                 })
             );
+        verify(response.headers()).set("WWW-Authenticate", "Bearer realm=\"api-gateway\"");
     }
 
     @Test
@@ -374,6 +393,7 @@ class JWTPolicyTest {
         when(ctx.request()).thenReturn(request);
         when(request.headers()).thenReturn(headers);
         when(ctx.interruptWith(any())).thenReturn(Completable.error(new RuntimeException(MOCK_EXCEPTION)));
+        when(configuration.isSendWwwAuthenticateHeader()).thenReturn(true);
 
         final TestObserver<Void> obs = cut.onRequest(ctx).test();
         obs.assertError(Throwable.class);
@@ -389,6 +409,11 @@ class JWTPolicyTest {
 
                     return true;
                 })
+            );
+        verify(response.headers())
+            .set(
+                "WWW-Authenticate",
+                "Bearer realm=\"api-gateway\", error=\"invalid_token\", error_description=\"The access token is invalid or expired\""
             );
     }
 
@@ -406,6 +431,7 @@ class JWTPolicyTest {
         when(ctx.request()).thenReturn(request);
         when(ctx.metrics()).thenReturn(metrics);
         when(ctx.interruptWith(any())).thenReturn(Completable.error(new RuntimeException(MOCK_EXCEPTION)));
+        when(configuration.isSendWwwAuthenticateHeader()).thenReturn(true);
 
         final TestObserver<Void> obs = cut.onRequest(ctx).test();
         obs.assertError(Throwable.class);
@@ -424,6 +450,77 @@ class JWTPolicyTest {
             );
 
         verify(metrics).setErrorMessage(MOCK_JOSE_EXCEPTION);
+        verify(response.headers())
+            .set(
+                "WWW-Authenticate",
+                "Bearer realm=\"api-gateway\", error=\"invalid_token\", error_description=\"The access token is invalid or expired\""
+            );
+    }
+
+    @Test
+    void should_error_with_401_expired_token_interruption_when_claims_are_expired() throws BadJOSEException, JOSEException {
+        final Metrics metrics = mock(Metrics.class);
+
+        final HttpHeaders headers = mock(HttpHeaders.class);
+        when(headers.getAll(HttpHeaderNames.AUTHORIZATION)).thenReturn(List.of("Bearer " + TOKEN));
+        when(request.headers()).thenReturn(headers);
+
+        when(jwtProcessorResolver.provide(ctx)).thenReturn(Maybe.just(jwtProcessor));
+        when(jwtProcessor.process(Mockito.<JWT>argThat(jwt -> TOKEN.equals(jwt.getParsedString())), isNull()))
+            .thenThrow(new BadJWTException("Expired JWT"));
+        when(ctx.request()).thenReturn(request);
+        when(ctx.metrics()).thenReturn(metrics);
+        when(ctx.interruptWith(any())).thenReturn(Completable.error(new RuntimeException(MOCK_EXCEPTION)));
+        when(configuration.isSendWwwAuthenticateHeader()).thenReturn(true);
+
+        final TestObserver<Void> obs = cut.onRequest(ctx).test();
+        obs.assertError(Throwable.class);
+
+        verify(ctx)
+            .interruptWith(
+                argThat(failure -> {
+                    assertEquals(HttpStatusCode.UNAUTHORIZED_401, failure.statusCode());
+                    assertEquals(UNAUTHORIZED_MESSAGE, failure.message());
+                    assertEquals(JWTPolicy.JWT_EXPIRED_TOKEN_KEY, failure.key());
+                    return true;
+                })
+            );
+
+        verify(response.headers())
+            .set(
+                "WWW-Authenticate",
+                "Bearer realm=\"api-gateway\", error=\"invalid_token\", error_description=\"The access token is expired\""
+            );
+    }
+
+    @Test
+    void should_use_custom_realm_in_www_authenticate_header() {
+        final HttpHeaders headers = mock(HttpHeaders.class);
+        when(headers.getAll(HttpHeaderNames.AUTHORIZATION)).thenReturn(Collections.emptyList());
+        when(ctx.request()).thenReturn(request);
+        when(request.headers()).thenReturn(headers);
+        when(ctx.interruptWith(any())).thenReturn(Completable.error(new RuntimeException(MOCK_EXCEPTION)));
+        when(configuration.getRealm()).thenReturn("my-custom-realm");
+        when(configuration.isSendWwwAuthenticateHeader()).thenReturn(true);
+
+        final TestObserver<Void> obs = cut.onRequest(ctx).test();
+        obs.assertError(Throwable.class);
+
+        verify(response.headers()).set("WWW-Authenticate", "Bearer realm=\"my-custom-realm\"");
+    }
+
+    @Test
+    void should_not_send_www_authenticate_header_when_disabled() {
+        final HttpHeaders headers = mock(HttpHeaders.class);
+        when(headers.getAll(HttpHeaderNames.AUTHORIZATION)).thenReturn(Collections.emptyList());
+        when(ctx.request()).thenReturn(request);
+        when(request.headers()).thenReturn(headers);
+        when(ctx.interruptWith(any())).thenReturn(Completable.error(new RuntimeException(MOCK_EXCEPTION)));
+
+        final TestObserver<Void> obs = cut.onRequest(ctx).test();
+        obs.assertError(Throwable.class);
+
+        verify(response.headers(), Mockito.never()).set(eq("WWW-Authenticate"), any(String.class));
     }
 
     @Test
@@ -487,6 +584,107 @@ class JWTPolicyTest {
         final TestObserver<SecurityToken> obs = cut.extractSecurityToken(ctx).test();
 
         obs.assertComplete().assertValueCount(0);
+    }
+
+    @Test
+    void extractSecurityToken_should_set_www_authenticate_header_when_token_is_absent_and_feature_enabled() {
+        final HttpHeaders headers = mock(HttpHeaders.class);
+
+        when(ctx.request()).thenReturn(request);
+        when(request.headers()).thenReturn(headers);
+        when(configuration.isSendWwwAuthenticateHeader()).thenReturn(true);
+
+        final TestObserver<SecurityToken> obs = cut.extractSecurityToken(ctx).test();
+
+        obs.assertComplete().assertValueCount(0);
+        verify(response.headers()).set("WWW-Authenticate", "Bearer realm=\"api-gateway\"");
+    }
+
+    @Test
+    void extractSecurityToken_should_not_set_www_authenticate_header_when_token_is_absent_and_feature_disabled() {
+        final HttpHeaders headers = mock(HttpHeaders.class);
+
+        when(ctx.request()).thenReturn(request);
+        when(request.headers()).thenReturn(headers);
+
+        final TestObserver<SecurityToken> obs = cut.extractSecurityToken(ctx).test();
+
+        obs.assertComplete().assertValueCount(0);
+        verify(response.headers(), Mockito.never()).set(eq("WWW-Authenticate"), any(String.class));
+    }
+
+    @Test
+    void extractSecurityToken_should_set_www_authenticate_header_when_token_has_no_client_id_and_feature_enabled() {
+        final HttpHeaders headers = mock(HttpHeaders.class);
+
+        when(ctx.request()).thenReturn(request);
+        when(request.headers()).thenReturn(headers);
+        when(headers.getAll(HttpHeaderNames.AUTHORIZATION)).thenReturn(List.of("Bearer " + TOKEN_WITHOUT_CLIENT_ID));
+        when(configuration.isSendWwwAuthenticateHeader()).thenReturn(true);
+
+        final TestObserver<SecurityToken> obs = cut.extractSecurityToken(ctx).test();
+
+        obs.assertComplete().assertValueCount(1).assertValue(SecurityToken::isInvalid);
+        verify(response.headers())
+            .set(
+                "WWW-Authenticate",
+                "Bearer realm=\"api-gateway\", error=\"invalid_token\", error_description=\"The access token does not contain a valid client_id claim\""
+            );
+    }
+
+    @Test
+    void extractSecurityToken_should_not_set_www_authenticate_header_when_token_has_no_client_id_and_feature_disabled() {
+        final HttpHeaders headers = mock(HttpHeaders.class);
+
+        when(ctx.request()).thenReturn(request);
+        when(request.headers()).thenReturn(headers);
+        when(headers.getAll(HttpHeaderNames.AUTHORIZATION)).thenReturn(List.of("Bearer " + TOKEN_WITHOUT_CLIENT_ID));
+
+        final TestObserver<SecurityToken> obs = cut.extractSecurityToken(ctx).test();
+
+        obs.assertComplete().assertValueCount(1).assertValue(SecurityToken::isInvalid);
+        verify(response.headers(), Mockito.never()).set(eq("WWW-Authenticate"), any(String.class));
+    }
+
+    @Test
+    void extractSecurityToken_should_not_set_www_authenticate_header_when_token_is_present_even_if_feature_enabled() {
+        final HttpHeaders headers = mock(HttpHeaders.class);
+
+        when(ctx.request()).thenReturn(request);
+        when(request.headers()).thenReturn(headers);
+        when(headers.getAll(HttpHeaderNames.AUTHORIZATION)).thenReturn(List.of("Bearer " + TOKEN));
+
+        final TestObserver<SecurityToken> obs = cut.extractSecurityToken(ctx).test();
+
+        obs.assertComplete().assertValueCount(1);
+        verify(response.headers(), Mockito.never()).set(eq("WWW-Authenticate"), any(String.class));
+    }
+
+    @Test
+    void onRequest_should_not_set_www_authenticate_header_on_successful_authentication() throws BadJOSEException, JOSEException {
+        final Metrics metrics = mock(Metrics.class);
+        final HttpHeaders headers = mock(HttpHeaders.class);
+        final JWTClaimsSet claimsSet = new JWTClaimsSet.Builder()
+            .issuer(ISSUER)
+            .subject(STANDARD_SUBJECT)
+            .claim(CONTEXT_ATTRIBUTE_CLIENT_ID, CLIENT_ID)
+            .expirationTime(new Date(System.currentTimeMillis() + 3600000))
+            .build();
+
+        when(headers.getAll(HttpHeaderNames.AUTHORIZATION)).thenReturn(List.of("Bearer " + TOKEN));
+        when(jwtProcessorResolver.provide(ctx)).thenReturn(Maybe.just(jwtProcessor));
+        when(jwtProcessor.process(any(JWT.class), isNull())).thenReturn(claimsSet);
+        when(ctx.request()).thenReturn(request);
+        when(ctx.metrics()).thenReturn(metrics);
+        when(ctx.getAttribute(CONTEXT_ATTRIBUTE_OAUTH_CLIENT_ID)).thenReturn(CLIENT_ID);
+        when(ctx.getAttribute(ATTR_USER)).thenReturn(STANDARD_SUBJECT);
+        when(request.headers()).thenReturn(headers);
+
+        final TestObserver<Void> obs = cut.onRequest(ctx).test();
+        obs.assertComplete();
+
+        verify(response.headers(), Mockito.never()).set(eq("WWW-Authenticate"), any(String.class));
+        verify(response.headers(), Mockito.never()).remove("WWW-Authenticate");
     }
 
     private void verifyMetricsAttributesAndHeaders(Metrics metrics, HttpHeaders headers, String expectedClientId, String expectedSubject) {

--- a/src/test/java/io/gravitee/policy/jwt/JWTPolicyTest.java
+++ b/src/test/java/io/gravitee/policy/jwt/JWTPolicyTest.java
@@ -38,6 +38,7 @@ import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.isNull;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -47,6 +48,7 @@ import com.nimbusds.jose.proc.SecurityContext;
 import com.nimbusds.jwt.JWT;
 import com.nimbusds.jwt.JWTClaimNames;
 import com.nimbusds.jwt.JWTClaimsSet;
+import com.nimbusds.jwt.proc.BadJWTException;
 import com.nimbusds.jwt.proc.JWTProcessor;
 import io.gravitee.common.http.HttpStatusCode;
 import io.gravitee.common.security.jwt.LazyJWT;
@@ -54,6 +56,7 @@ import io.gravitee.gateway.api.http.HttpHeaderNames;
 import io.gravitee.gateway.api.http.HttpHeaders;
 import io.gravitee.gateway.reactive.api.context.http.HttpPlainExecutionContext;
 import io.gravitee.gateway.reactive.api.context.http.HttpPlainRequest;
+import io.gravitee.gateway.reactive.api.context.http.HttpPlainResponse;
 import io.gravitee.gateway.reactive.api.policy.SecurityToken;
 import io.gravitee.policy.jwt.configuration.JWTPolicyConfiguration;
 import io.gravitee.policy.jwt.configuration.RevocationCheckConfiguration;
@@ -117,6 +120,9 @@ class JWTPolicyTest {
     private HttpPlainRequest request;
 
     @Mock
+    private HttpPlainResponse response;
+
+    @Mock
     private RevocationChecker revocationChecker;
 
     private JWTPolicy cut;
@@ -132,6 +138,10 @@ class JWTPolicyTest {
     private void prepareClaimsSetCacheMocking() {
         lenient().when(ctx.getAttribute(ATTR_API)).thenReturn("API_ID");
         lenient().when(ctx.getAttribute(CONTEXT_ATTRIBUTE_JWT)).thenReturn(null);
+        lenient().when(configuration.getRealm()).thenReturn("api-gateway");
+        lenient().when(ctx.response()).thenReturn(response);
+        HttpHeaders responseHeaders = mock(HttpHeaders.class);
+        lenient().when(response.headers()).thenReturn(responseHeaders);
     }
 
     private static Stream<Arguments> provideClientIdParameters() {
@@ -314,6 +324,11 @@ class JWTPolicyTest {
                     return true;
                 })
             );
+        verify(response.headers())
+            .set(
+                "WWW-Authenticate",
+                "Bearer realm=\"api-gateway\", error=\"invalid_token\", error_description=\"The access token has been revoked\""
+            );
     }
 
     @Test
@@ -337,6 +352,11 @@ class JWTPolicyTest {
 
                     return true;
                 })
+            );
+        verify(response.headers())
+            .set(
+                "WWW-Authenticate",
+                "Bearer realm=\"api-gateway\", error=\"invalid_request\", error_description=\"No access token was provided\""
             );
     }
 
@@ -364,6 +384,11 @@ class JWTPolicyTest {
                     return true;
                 })
             );
+        verify(response.headers())
+            .set(
+                "WWW-Authenticate",
+                "Bearer realm=\"api-gateway\", error=\"invalid_request\", error_description=\"No access token was provided\""
+            );
     }
 
     @Test
@@ -389,6 +414,11 @@ class JWTPolicyTest {
 
                     return true;
                 })
+            );
+        verify(response.headers())
+            .set(
+                "WWW-Authenticate",
+                "Bearer realm=\"api-gateway\", error=\"invalid_token\", error_description=\"The access token is invalid\""
             );
     }
 
@@ -424,6 +454,65 @@ class JWTPolicyTest {
             );
 
         verify(metrics).setErrorMessage(MOCK_JOSE_EXCEPTION);
+        verify(response.headers())
+            .set(
+                "WWW-Authenticate",
+                "Bearer realm=\"api-gateway\", error=\"invalid_token\", error_description=\"The access token is invalid\""
+            );
+    }
+
+    @Test
+    void should_error_with_401_expired_token_interruption_when_claims_are_expired() throws BadJOSEException, JOSEException {
+        final Metrics metrics = mock(Metrics.class);
+
+        final HttpHeaders headers = mock(HttpHeaders.class);
+        when(headers.getAll(HttpHeaderNames.AUTHORIZATION)).thenReturn(List.of("Bearer " + TOKEN));
+        when(request.headers()).thenReturn(headers);
+
+        when(jwtProcessorResolver.provide(ctx)).thenReturn(Maybe.just(jwtProcessor));
+        when(jwtProcessor.process(Mockito.<JWT>argThat(jwt -> TOKEN.equals(jwt.getParsedString())), isNull()))
+            .thenThrow(new BadJWTException("Expired JWT"));
+        when(ctx.request()).thenReturn(request);
+        when(ctx.metrics()).thenReturn(metrics);
+        when(ctx.interruptWith(any())).thenReturn(Completable.error(new RuntimeException(MOCK_EXCEPTION)));
+
+        final TestObserver<Void> obs = cut.onRequest(ctx).test();
+        obs.assertError(Throwable.class);
+
+        verify(ctx)
+            .interruptWith(
+                argThat(failure -> {
+                    assertEquals(HttpStatusCode.UNAUTHORIZED_401, failure.statusCode());
+                    assertEquals(UNAUTHORIZED_MESSAGE, failure.message());
+                    assertEquals(JWTPolicy.JWT_EXPIRED_TOKEN_KEY, failure.key());
+                    return true;
+                })
+            );
+
+        verify(response.headers())
+            .set(
+                "WWW-Authenticate",
+                "Bearer realm=\"api-gateway\", error=\"invalid_token\", error_description=\"The access token is expired\""
+            );
+    }
+
+    @Test
+    void should_use_custom_realm_in_www_authenticate_header() {
+        final HttpHeaders headers = mock(HttpHeaders.class);
+        when(headers.getAll(HttpHeaderNames.AUTHORIZATION)).thenReturn(Collections.emptyList());
+        when(ctx.request()).thenReturn(request);
+        when(request.headers()).thenReturn(headers);
+        when(ctx.interruptWith(any())).thenReturn(Completable.error(new RuntimeException(MOCK_EXCEPTION)));
+        when(configuration.getRealm()).thenReturn("my-custom-realm");
+
+        final TestObserver<Void> obs = cut.onRequest(ctx).test();
+        obs.assertError(Throwable.class);
+
+        verify(response.headers())
+            .set(
+                "WWW-Authenticate",
+                "Bearer realm=\"my-custom-realm\", error=\"invalid_request\", error_description=\"No access token was provided\""
+            );
     }
 
     @Test
@@ -487,6 +576,81 @@ class JWTPolicyTest {
         final TestObserver<SecurityToken> obs = cut.extractSecurityToken(ctx).test();
 
         obs.assertComplete().assertValueCount(0);
+    }
+
+    @Test
+    void extractSecurityToken_should_set_www_authenticate_header_when_token_is_absent() {
+        final HttpHeaders headers = mock(HttpHeaders.class);
+
+        when(ctx.request()).thenReturn(request);
+        when(request.headers()).thenReturn(headers);
+
+        final TestObserver<SecurityToken> obs = cut.extractSecurityToken(ctx).test();
+
+        obs.assertComplete().assertValueCount(0);
+        verify(response.headers())
+            .set(
+                "WWW-Authenticate",
+                "Bearer realm=\"api-gateway\", error=\"invalid_request\", error_description=\"No access token was provided\""
+            );
+    }
+
+    @Test
+    void extractSecurityToken_should_set_www_authenticate_header_when_token_has_no_client_id() {
+        final HttpHeaders headers = mock(HttpHeaders.class);
+
+        when(ctx.request()).thenReturn(request);
+        when(request.headers()).thenReturn(headers);
+        when(headers.getAll(HttpHeaderNames.AUTHORIZATION)).thenReturn(List.of("Bearer " + TOKEN_WITHOUT_CLIENT_ID));
+
+        final TestObserver<SecurityToken> obs = cut.extractSecurityToken(ctx).test();
+
+        obs.assertComplete().assertValueCount(1).assertValue(SecurityToken::isInvalid);
+        verify(response.headers())
+            .set(
+                "WWW-Authenticate",
+                "Bearer realm=\"api-gateway\", error=\"invalid_token\", error_description=\"The access token does not contain a valid client_id claim\""
+            );
+    }
+
+    @Test
+    void extractSecurityToken_should_not_set_www_authenticate_header_when_clientId_extracted() {
+        final HttpHeaders headers = mock(HttpHeaders.class);
+
+        when(ctx.request()).thenReturn(request);
+        when(request.headers()).thenReturn(headers);
+        when(headers.getAll(HttpHeaderNames.AUTHORIZATION)).thenReturn(List.of("Bearer " + TOKEN));
+
+        final TestObserver<SecurityToken> obs = cut.extractSecurityToken(ctx).test();
+
+        obs.assertComplete().assertValueCount(1);
+        verify(response.headers(), never()).set(eq("WWW-Authenticate"), Mockito.<CharSequence>any());
+    }
+
+    @Test
+    void onRequest_should_not_set_www_authenticate_header_on_successful_authentication() throws BadJOSEException, JOSEException {
+        final Metrics metrics = mock(Metrics.class);
+        final HttpHeaders headers = mock(HttpHeaders.class);
+        final JWTClaimsSet claimsSet = new JWTClaimsSet.Builder()
+            .issuer(ISSUER)
+            .subject(STANDARD_SUBJECT)
+            .claim(CONTEXT_ATTRIBUTE_CLIENT_ID, CLIENT_ID)
+            .expirationTime(new Date(System.currentTimeMillis() + 3600000))
+            .build();
+
+        when(headers.getAll(HttpHeaderNames.AUTHORIZATION)).thenReturn(List.of("Bearer " + TOKEN));
+        when(jwtProcessorResolver.provide(ctx)).thenReturn(Maybe.just(jwtProcessor));
+        when(jwtProcessor.process(any(JWT.class), isNull())).thenReturn(claimsSet);
+        when(ctx.request()).thenReturn(request);
+        when(ctx.metrics()).thenReturn(metrics);
+        when(ctx.getAttribute(CONTEXT_ATTRIBUTE_OAUTH_CLIENT_ID)).thenReturn(CLIENT_ID);
+        when(ctx.getAttribute(ATTR_USER)).thenReturn(STANDARD_SUBJECT);
+        when(request.headers()).thenReturn(headers);
+
+        final TestObserver<Void> obs = cut.onRequest(ctx).test();
+        obs.assertComplete();
+
+        verify(response.headers()).remove("WWW-Authenticate");
     }
 
     private void verifyMetricsAttributesAndHeaders(Metrics metrics, HttpHeaders headers, String expectedClientId, String expectedSubject) {

--- a/src/test/java/io/gravitee/policy/jwt/JwtPolicyV4EmulationEngineIntegrationTest.java
+++ b/src/test/java/io/gravitee/policy/jwt/JwtPolicyV4EmulationEngineIntegrationTest.java
@@ -91,6 +91,7 @@ public class JwtPolicyV4EmulationEngineIntegrationTest extends AbstractPolicyTes
         configuration.setSignature(HMAC_HS256);
         configuration.setResolverParameter(JWT_SECRET);
         configuration.setPublicKeyResolver(GIVEN_KEY);
+        configuration.setSendWwwAuthenticateHeader(true);
         try {
             jwtPlan.setSecurityDefinition(new ObjectMapper().writeValueAsString(configuration));
         } catch (JsonProcessingException e) {
@@ -107,7 +108,7 @@ public class JwtPolicyV4EmulationEngineIntegrationTest extends AbstractPolicyTes
 
         Single<HttpClientResponse> httpClientResponse = httpClient.rxRequest(GET, "/test").flatMap(HttpClientRequest::rxSend);
 
-        assert401unauthorized(httpClientResponse);
+        assert401unauthorized(httpClientResponse, expectedMissingTokenHeader());
     }
 
     @Test
@@ -119,7 +120,7 @@ public class JwtPolicyV4EmulationEngineIntegrationTest extends AbstractPolicyTes
             .rxRequest(GET, "/test")
             .flatMap(request -> request.putHeader("Authorization", "Bearer").rxSend());
 
-        assert401unauthorized(httpClientResponse);
+        assert401unauthorized(httpClientResponse, expectedInvalidTokenHeader());
     }
 
     @Test
@@ -131,7 +132,7 @@ public class JwtPolicyV4EmulationEngineIntegrationTest extends AbstractPolicyTes
             .rxRequest(GET, "/test")
             .flatMap(request -> request.putHeader("Authorization", "Bearer this_is_wrong").rxSend());
 
-        assert401unauthorized(httpClientResponse);
+        assert401unauthorized(httpClientResponse, expectedInvalidTokenHeader());
     }
 
     @Test
@@ -145,41 +146,21 @@ public class JwtPolicyV4EmulationEngineIntegrationTest extends AbstractPolicyTes
             .rxRequest(GET, "/test")
             .flatMap(request -> request.putHeader("Authorization", "Bearer " + jwtToken).rxSend());
 
-        assert401unauthorized(httpClientResponse);
+        assert401unauthorized(httpClientResponse, null);
     }
 
     @Test
-    @DisplayName("Should receive 401 - Unauthorized when calling with an valid token, but no subscription")
-    void shouldGet401_ifNoSubscription(HttpClient httpClient) throws Exception {
+    @DisplayName("Should receive 401 - Unauthorized when calling with valid token but missing client_id claim")
+    void shouldGet401_ifTokenHasNoClientId(HttpClient httpClient) throws Exception {
         wiremock.stubFor(get("/team").willReturn(ok("response from backend")));
 
-        String jwtToken = getJsonWebToken(5000);
-
-        // no subscription found
-        whenSearchingSubscription(API_ID, CLIENT_ID, PLAN_ID).thenReturn(Optional.empty());
+        String jwtToken = getJsonWebTokenWithoutClientId(5000);
 
         Single<HttpClientResponse> httpClientResponse = httpClient
             .rxRequest(GET, "/test")
             .flatMap(request -> request.putHeader("Authorization", "Bearer " + jwtToken).rxSend());
 
-        assert401unauthorized(httpClientResponse);
-    }
-
-    @Test
-    @DisplayName("Should receive 401 - Unauthorized when calling with an valid token, but subscription is expired")
-    void shouldGet401_ifSubscriptionExpired(HttpClient httpClient) throws Exception {
-        wiremock.stubFor(get("/team").willReturn(ok("response from backend")));
-
-        String jwtToken = getJsonWebToken(5000);
-
-        // subscription found is expired
-        whenSearchingSubscription(API_ID, CLIENT_ID, PLAN_ID).thenReturn(Optional.of(fakeSubscriptionFromCache(true)));
-
-        Single<HttpClientResponse> httpClientResponse = httpClient
-            .rxRequest(GET, "/test")
-            .flatMap(request -> request.putHeader("Authorization", "Bearer " + jwtToken).rxSend());
-
-        assert401unauthorized(httpClientResponse);
+        assert401unauthorized(httpClientResponse, expectedInvalidClientIdHeader());
     }
 
     @Test
@@ -197,6 +178,7 @@ public class JwtPolicyV4EmulationEngineIntegrationTest extends AbstractPolicyTes
             .flatMap(request -> request.putHeader("Authorization", "Bearer " + jwtToken).rxSend())
             .flatMapPublisher(response -> {
                 assertThat(response.statusCode()).isEqualTo(200);
+                assertThat(response.getHeader("WWW-Authenticate")).isNull();
                 return response.toFlowable();
             })
             .test()
@@ -236,10 +218,31 @@ public class JwtPolicyV4EmulationEngineIntegrationTest extends AbstractPolicyTes
         return signedJWT.serialize();
     }
 
-    private void assert401unauthorized(Single<HttpClientResponse> httpClientResponse) throws InterruptedException {
+    private String getJsonWebTokenWithoutClientId(long secondsToAdd) throws Exception {
+        JWTClaimsSet jwtClaimsSet = new JWTClaimsSet.Builder().expirationTime(Date.from(Instant.now().plusSeconds(secondsToAdd))).build();
+        SignedJWT signedJWT = new SignedJWT(new JWSHeader(HMAC_HS256.getAlg()), jwtClaimsSet);
+        signedJWT.sign(new MACSigner(JWT_SECRET));
+        return signedJWT.serialize();
+    }
+
+    protected String expectedMissingTokenHeader() {
+        return "Bearer realm=\"api-gateway\"";
+    }
+
+    protected String expectedInvalidTokenHeader() {
+        return "Bearer realm=\"api-gateway\", error=\"invalid_token\", error_description=\"The access token is invalid or expired\"";
+    }
+
+    protected String expectedInvalidClientIdHeader() {
+        return "Bearer realm=\"api-gateway\", error=\"invalid_token\", error_description=\"The access token does not contain a valid client_id claim\"";
+    }
+
+    private void assert401unauthorized(Single<HttpClientResponse> httpClientResponse, String expectedWwwAuthenticateHeader)
+        throws InterruptedException {
         httpClientResponse
             .flatMapPublisher(response -> {
                 assertThat(response.statusCode()).isEqualTo(401);
+                assertThat(response.getHeader("WWW-Authenticate")).isEqualTo(expectedWwwAuthenticateHeader);
                 return response.toFlowable();
             })
             .test()

--- a/src/test/java/io/gravitee/policy/jwt/JwtPolicyV4EmulationEngineIntegrationTest.java
+++ b/src/test/java/io/gravitee/policy/jwt/JwtPolicyV4EmulationEngineIntegrationTest.java
@@ -107,7 +107,7 @@ public class JwtPolicyV4EmulationEngineIntegrationTest extends AbstractPolicyTes
 
         Single<HttpClientResponse> httpClientResponse = httpClient.rxRequest(GET, "/test").flatMap(HttpClientRequest::rxSend);
 
-        assert401unauthorized(httpClientResponse);
+        assert401unauthorized(httpClientResponse, expectedMissingTokenHeader());
     }
 
     @Test
@@ -119,7 +119,7 @@ public class JwtPolicyV4EmulationEngineIntegrationTest extends AbstractPolicyTes
             .rxRequest(GET, "/test")
             .flatMap(request -> request.putHeader("Authorization", "Bearer").rxSend());
 
-        assert401unauthorized(httpClientResponse);
+        assert401unauthorized(httpClientResponse, expectedInvalidTokenHeader());
     }
 
     @Test
@@ -131,7 +131,7 @@ public class JwtPolicyV4EmulationEngineIntegrationTest extends AbstractPolicyTes
             .rxRequest(GET, "/test")
             .flatMap(request -> request.putHeader("Authorization", "Bearer this_is_wrong").rxSend());
 
-        assert401unauthorized(httpClientResponse);
+        assert401unauthorized(httpClientResponse, expectedInvalidTokenHeader());
     }
 
     @Test
@@ -139,47 +139,29 @@ public class JwtPolicyV4EmulationEngineIntegrationTest extends AbstractPolicyTes
     void shouldGet401_ifExpiredToken(HttpClient httpClient) throws Exception {
         wiremock.stubFor(get("/team").willReturn(ok("response from backend")));
 
-        String jwtToken = getJsonWebToken(-50);
+        String jwtToken = getJsonWebToken(-120);
+
+        whenSearchingSubscription(API_ID, CLIENT_ID, PLAN_ID).thenReturn(Optional.of(fakeSubscriptionFromCache(false)));
 
         Single<HttpClientResponse> httpClientResponse = httpClient
             .rxRequest(GET, "/test")
             .flatMap(request -> request.putHeader("Authorization", "Bearer " + jwtToken).rxSend());
 
-        assert401unauthorized(httpClientResponse);
+        assert401unauthorized(httpClientResponse, expectedExpiredTokenHeader());
     }
 
     @Test
-    @DisplayName("Should receive 401 - Unauthorized when calling with an valid token, but no subscription")
-    void shouldGet401_ifNoSubscription(HttpClient httpClient) throws Exception {
+    @DisplayName("Should receive 401 - Unauthorized when calling with valid token but missing client_id claim")
+    void shouldGet401_ifTokenHasNoClientId(HttpClient httpClient) throws Exception {
         wiremock.stubFor(get("/team").willReturn(ok("response from backend")));
 
-        String jwtToken = getJsonWebToken(5000);
-
-        // no subscription found
-        whenSearchingSubscription(API_ID, CLIENT_ID, PLAN_ID).thenReturn(Optional.empty());
+        String jwtToken = getJsonWebTokenWithoutClientId(5000);
 
         Single<HttpClientResponse> httpClientResponse = httpClient
             .rxRequest(GET, "/test")
             .flatMap(request -> request.putHeader("Authorization", "Bearer " + jwtToken).rxSend());
 
-        assert401unauthorized(httpClientResponse);
-    }
-
-    @Test
-    @DisplayName("Should receive 401 - Unauthorized when calling with an valid token, but subscription is expired")
-    void shouldGet401_ifSubscriptionExpired(HttpClient httpClient) throws Exception {
-        wiremock.stubFor(get("/team").willReturn(ok("response from backend")));
-
-        String jwtToken = getJsonWebToken(5000);
-
-        // subscription found is expired
-        whenSearchingSubscription(API_ID, CLIENT_ID, PLAN_ID).thenReturn(Optional.of(fakeSubscriptionFromCache(true)));
-
-        Single<HttpClientResponse> httpClientResponse = httpClient
-            .rxRequest(GET, "/test")
-            .flatMap(request -> request.putHeader("Authorization", "Bearer " + jwtToken).rxSend());
-
-        assert401unauthorized(httpClientResponse);
+        assert401unauthorized(httpClientResponse, expectedInvalidClientIdHeader());
     }
 
     @Test
@@ -197,6 +179,7 @@ public class JwtPolicyV4EmulationEngineIntegrationTest extends AbstractPolicyTes
             .flatMap(request -> request.putHeader("Authorization", "Bearer " + jwtToken).rxSend())
             .flatMapPublisher(response -> {
                 assertThat(response.statusCode()).isEqualTo(200);
+                assertThat(response.getHeader("WWW-Authenticate")).isNull();
                 return response.toFlowable();
             })
             .test()
@@ -236,10 +219,37 @@ public class JwtPolicyV4EmulationEngineIntegrationTest extends AbstractPolicyTes
         return signedJWT.serialize();
     }
 
-    private void assert401unauthorized(Single<HttpClientResponse> httpClientResponse) throws InterruptedException {
+    private String getJsonWebTokenWithoutClientId(long secondsToAdd) throws Exception {
+        JWTClaimsSet jwtClaimsSet = new JWTClaimsSet.Builder().expirationTime(Date.from(Instant.now().plusSeconds(secondsToAdd))).build();
+        SignedJWT signedJWT = new SignedJWT(new JWSHeader(HMAC_HS256.getAlg()), jwtClaimsSet);
+        signedJWT.sign(new MACSigner(JWT_SECRET));
+        return signedJWT.serialize();
+    }
+
+    protected String expectedMissingTokenHeader() {
+        return "Bearer realm=\"api-gateway\", error=\"invalid_request\", error_description=\"No access token was provided\"";
+    }
+
+    protected String expectedInvalidTokenHeader() {
+        return "Bearer realm=\"api-gateway\", error=\"invalid_token\", error_description=\"The access token is invalid\"";
+    }
+
+    protected String expectedExpiredTokenHeader() {
+        return "Bearer realm=\"api-gateway\", error=\"invalid_token\", error_description=\"The access token is expired\"";
+    }
+
+    protected String expectedInvalidClientIdHeader() {
+        return "Bearer realm=\"api-gateway\", error=\"invalid_token\", error_description=\"The access token does not contain a valid client_id claim\"";
+    }
+
+    private void assert401unauthorized(Single<HttpClientResponse> httpClientResponse, String expectedWwwAuthenticateHeader)
+        throws InterruptedException {
         httpClientResponse
             .flatMapPublisher(response -> {
                 assertThat(response.statusCode()).isEqualTo(401);
+                if (expectedWwwAuthenticateHeader != null) {
+                    assertThat(response.getHeader("WWW-Authenticate")).isEqualTo(expectedWwwAuthenticateHeader);
+                }
                 return response.toFlowable();
             })
             .test()

--- a/src/test/java/io/gravitee/policy/v3/jwt/JWTPolicyV3Test.java
+++ b/src/test/java/io/gravitee/policy/v3/jwt/JWTPolicyV3Test.java
@@ -416,7 +416,7 @@ public abstract class JWTPolicyV3Test {
         verify(policyChain, times(1))
             .failWith(
                 argThat(result ->
-                    result.statusCode() == HttpStatusCode.UNAUTHORIZED_401 && JWTPolicyV3.JWT_INVALID_TOKEN_KEY.equals(result.key())
+                    result.statusCode() == HttpStatusCode.UNAUTHORIZED_401 && JWTPolicyV3.JWT_EXPIRED_TOKEN_KEY.equals(result.key())
                 )
             );
         verify(policyChain, never()).doNext(request, response);

--- a/src/test/java/io/gravitee/policy/v3/jwt/JwtPolicyV3IntegrationTest.java
+++ b/src/test/java/io/gravitee/policy/v3/jwt/JwtPolicyV3IntegrationTest.java
@@ -40,4 +40,24 @@ public class JwtPolicyV3IntegrationTest extends JwtPolicyV4EmulationEngineIntegr
     protected OngoingStubbing<Optional<Subscription>> whenSearchingSubscription(String api, String clientId, String plan) {
         return when(getBean(SubscriptionService.class).getByApiAndClientIdAndPlan(api, clientId, plan));
     }
+
+    @Override
+    protected String expectedMissingTokenHeader() {
+        return null;
+    }
+
+    @Override
+    protected String expectedInvalidTokenHeader() {
+        return null;
+    }
+
+    @Override
+    protected String expectedInvalidClientIdHeader() {
+        return null;
+    }
+
+    @Override
+    protected String expectedExpiredTokenHeader() {
+        return null;
+    }
 }

--- a/src/test/java/io/gravitee/policy/v3/jwt/JwtPolicyV3IntegrationTest.java
+++ b/src/test/java/io/gravitee/policy/v3/jwt/JwtPolicyV3IntegrationTest.java
@@ -40,4 +40,19 @@ public class JwtPolicyV3IntegrationTest extends JwtPolicyV4EmulationEngineIntegr
     protected OngoingStubbing<Optional<Subscription>> whenSearchingSubscription(String api, String clientId, String plan) {
         return when(getBean(SubscriptionService.class).getByApiAndClientIdAndPlan(api, clientId, plan));
     }
+
+    @Override
+    protected String expectedMissingTokenHeader() {
+        return null;
+    }
+
+    @Override
+    protected String expectedInvalidTokenHeader() {
+        return null;
+    }
+
+    @Override
+    protected String expectedInvalidClientIdHeader() {
+        return null;
+    }
 }


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/XXXXX

## Description

A small description of what you did in that PR.

## Additional context
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `6.2.3-fix-apim-13239-6-2-x-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/policy/gravitee-policy-jwt/6.2.3-fix-apim-13239-6-2-x-SNAPSHOT/gravitee-policy-jwt-6.2.3-fix-apim-13239-6-2-x-SNAPSHOT.zip)
  <!-- Version placeholder end -->
