### PR TITLE
Revert "Add support WWW-Authenticate header for JWT Policy"

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,7 +160,6 @@ policy:
 | JWKS URL request timeout<br>`requestTimeout`| integer|  | `2000`| Only applies when the resolver is JWKS_URL|
 | Resolver parameter<br>`resolverParameter`| string|  | | Set the signature key GIVEN_KEY or a JWKS_URL following selected resolver (support EL).|
 | Revocation Check<br>`revocationCheck`| object|  | | Define revocation check details. If enabled, will check the configured claim of the token against a cached revocation list and deny if a match is found. Disabled by default.<br/>See "Revocation Check" section.|
-| Send WWW-Authenticate header<br>`sendWwwAuthenticateHeader`| boolean|  | | Emit the WWW-Authenticate response header on unauthorized JWT requests.|
 | Signature<br>`signature`| enum (string)| ✅| `RSA_RS256`| Define how the JSON Web Token must be signed.<br>Values: `RSA_RS256` `RSA_RS384` `RSA_RS512` `HMAC_HS256` `HMAC_HS384` `HMAC_HS512`|
 | Token Type Validation<br>`tokenTypValidation`| object|  | | Define the token type to validate<br/>See "Token Type Validation" section.|
 | Use system proxy<br>`useSystemProxy`| boolean|  | | Use system proxy (make sense only when resolver is set to JWKS_URL)|

--- a/src/main/java/io/gravitee/policy/jwt/JWTPolicy.java
+++ b/src/main/java/io/gravitee/policy/jwt/JWTPolicy.java
@@ -45,7 +45,6 @@ import io.gravitee.policy.jwt.revocation.RevocationCheckerFactory;
 import io.gravitee.policy.jwt.utils.TokenExtractor;
 import io.gravitee.policy.processing.JWTClaimsSetValidator;
 import io.gravitee.policy.v3.jwt.JWTPolicyV3;
-import io.gravitee.policy.v3.jwt.exceptions.InvalidTokenException;
 import io.gravitee.reporter.api.v4.metric.Metrics;
 import io.netty.handler.codec.http.HttpResponseStatus;
 import io.reactivex.rxjava3.core.Completable;
@@ -77,13 +76,11 @@ public class JWTPolicy extends JWTPolicyV3 implements HttpSecurityPolicy, KafkaS
     private static final long DEFAULT_MAX_TOKEN_LIFETIME_MS = 60 * 60 * 1000L; // 1 hour
     public static final String JWT_REVOKED = "JWT_REVOKED";
     public static final String JWT_POLICY_ERROR_KEY = "JWT_POLICY_ERROR";
-    private static final String WWW_AUTHENTICATE_ERROR_INVALID_TOKEN = "invalid_token";
 
     // Error messages for RuntimeExceptions
     static final String ERROR_MSG_JWT_REVOKED = "JWT token has been revoked";
     static final String ERROR_MSG_MISSING_TOKEN = "Missing JWT token";
     static final String ERROR_MSG_EMPTY_TOKEN = "Empty JWT token";
-    static final String ERROR_MSG_INVALID_TOKEN = "Invalid JWT token";
     static final String ERROR_MSG_INVALID_THUMBPRINT = "Invalid certificate bound thumbprint";
 
     private static final Logger log = LoggerFactory.getLogger(JWTPolicy.class);
@@ -185,7 +182,7 @@ public class JWTPolicy extends JWTPolicyV3 implements HttpSecurityPolicy, KafkaS
                 Callback[] callbacks = ctx.callbacks();
                 for (Callback callback : callbacks) {
                     if (callback instanceof OAuthBearerValidatorCallback oauthCallback) {
-                        oauthCallback.error(WWW_AUTHENTICATE_ERROR_INVALID_TOKEN, null, null);
+                        oauthCallback.error("invalid_token", null, null);
                     }
                 }
 
@@ -346,7 +343,6 @@ public class JWTPolicy extends JWTPolicyV3 implements HttpSecurityPolicy, KafkaS
 
     private <T> Single<T> interruptUnauthorized(BaseExecutionContext ctx, String key, Throwable cause) {
         if (ctx instanceof HttpPlainExecutionContext httpPlainExecutionContext) {
-            setWwwAuthenticateHeaderIfPossible(httpPlainExecutionContext, key, cause);
             ExecutionFailure failure = new ExecutionFailure(UNAUTHORIZED_401).key(key).message(UNAUTHORIZED_MESSAGE);
             if (cause != null) {
                 failure = failure.cause(cause);
@@ -372,12 +368,6 @@ public class JWTPolicy extends JWTPolicyV3 implements HttpSecurityPolicy, KafkaS
 
         Throwable propagatedCause = Optional.ofNullable(failure.cause()).orElseGet(() -> new IllegalStateException(failure.key()));
         return Single.error(propagatedCause);
-    }
-
-    private void setWwwAuthenticateHeaderIfPossible(HttpPlainExecutionContext ctx, String key, Throwable cause) {
-        if (configuration.isSendWwwAuthenticateHeader() && ctx != null && ctx.response() != null && ctx.response().headers() != null) {
-            ctx.response().headers().set(WWW_AUTHENTICATE_HEADER, buildWwwAuthenticateValue(key, cause));
-        }
     }
 
     private void reportError(BaseExecutionContext ctx, Throwable throwable) {

--- a/src/main/java/io/gravitee/policy/jwt/configuration/JWTPolicyConfiguration.java
+++ b/src/main/java/io/gravitee/policy/jwt/configuration/JWTPolicyConfiguration.java
@@ -41,7 +41,6 @@ public class JWTPolicyConfiguration implements PolicyConfiguration {
     private Signature signature;
     private boolean extractClaims = false;
     private boolean propagateAuthHeader = true;
-    private boolean sendWwwAuthenticateHeader = false;
     private String userClaim;
     private String clientIdClaim;
     private boolean useSystemProxy;

--- a/src/main/java/io/gravitee/policy/v3/jwt/JWTPolicyV3.java
+++ b/src/main/java/io/gravitee/policy/v3/jwt/JWTPolicyV3.java
@@ -89,10 +89,6 @@ public class JWTPolicyV3 {
     public static final String JWT_MISSING_TOKEN_KEY = "JWT_MISSING_TOKEN";
     public static final String JWT_INVALID_TOKEN_KEY = "JWT_INVALID_TOKEN";
     public static final String JWT_INVALID_CERTIFICATE_BOUND_THUMBPRINT = "JWT_INVALID_CERTIFICATE_BOUND_THUMBPRINT";
-    protected static final String WWW_AUTHENTICATE_HEADER = "WWW-Authenticate";
-    protected static final String WWW_AUTHENTICATE_BEARER_VALUE = "Bearer";
-    private static final String WWW_AUTHENTICATE_ERROR_INVALID_REQUEST = "invalid_request";
-    private static final String WWW_AUTHENTICATE_ERROR_INVALID_TOKEN = "invalid_token";
     public static final String CLAIMS_CNF = "cnf";
     public static final String CLAIMS_CNF_X5T = "x5t#S256";
 
@@ -115,12 +111,6 @@ public class JWTPolicyV3 {
      */
     public JWTPolicyV3(JWTPolicyConfiguration configuration) {
         this.configuration = configuration;
-    }
-
-    protected void setWwwAuthenticateHeaderIfPossible(Response response, String key, Throwable cause) {
-        if (configuration.isSendWwwAuthenticateHeader() && response != null && response.headers() != null) {
-            response.headers().set(WWW_AUTHENTICATE_HEADER, buildWwwAuthenticateValue(key, cause));
-        }
     }
 
     @OnRequest
@@ -158,7 +148,6 @@ public class JWTPolicyV3 {
                             .setMessage(throwable.getCause() != null ? throwable.getCause().getMessage() : throwable.getMessage());
                     }
                     MDC.remove("api");
-                    setWwwAuthenticateHeaderIfPossible(response, key, throwable);
                     policyChain.failWith(PolicyResult.failure(key, HttpStatusCode.UNAUTHORIZED_401, UNAUTHORIZED_MESSAGE));
                 } else {
                     try {
@@ -204,21 +193,8 @@ public class JWTPolicyV3 {
                 e.getCause()
             );
             MDC.remove("api");
-            setWwwAuthenticateHeaderIfPossible(response, JWT_MISSING_TOKEN_KEY, e);
             policyChain.failWith(PolicyResult.failure(JWT_MISSING_TOKEN_KEY, HttpStatusCode.UNAUTHORIZED_401, UNAUTHORIZED_MESSAGE));
         }
-    }
-
-    protected String buildWwwAuthenticateValue(String key, Throwable cause) {
-        final String error = JWT_MISSING_TOKEN_KEY.equals(key)
-            ? WWW_AUTHENTICATE_ERROR_INVALID_REQUEST
-            : WWW_AUTHENTICATE_ERROR_INVALID_TOKEN;
-        final String description = Optional.ofNullable(cause).map(Throwable::getMessage).orElse(UNAUTHORIZED_MESSAGE);
-        return WWW_AUTHENTICATE_BEARER_VALUE + " error=\"" + error + "\", error_description=\"" + escapeHeaderValue(description) + "\"";
-    }
-
-    protected String escapeHeaderValue(String value) {
-        return value.replace("\\", "\\\\").replace("\"", "\\\"");
     }
 
     protected String getClientId(JWTClaimsSet claims) {

--- a/src/main/resources/schemas/schema-form.json
+++ b/src/main/resources/schemas/schema-form.json
@@ -130,12 +130,6 @@
             "type": "boolean",
             "default": true
         },
-        "sendWwwAuthenticateHeader": {
-            "title": "Send WWW-Authenticate header",
-            "description": "Emit the WWW-Authenticate response header on unauthorized JWT requests.",
-            "type": "boolean",
-            "default": false
-        },
         "userClaim": {
             "title": "User claim",
             "description": "Claim where the user can be extracted",

--- a/src/test/java/io/gravitee/policy/jwt/JWTPolicyTest.java
+++ b/src/test/java/io/gravitee/policy/jwt/JWTPolicyTest.java
@@ -38,7 +38,6 @@ import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.isNull;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -55,7 +54,6 @@ import io.gravitee.gateway.api.http.HttpHeaderNames;
 import io.gravitee.gateway.api.http.HttpHeaders;
 import io.gravitee.gateway.reactive.api.context.http.HttpPlainExecutionContext;
 import io.gravitee.gateway.reactive.api.context.http.HttpPlainRequest;
-import io.gravitee.gateway.reactive.api.context.http.HttpPlainResponse;
 import io.gravitee.gateway.reactive.api.policy.SecurityToken;
 import io.gravitee.policy.jwt.configuration.JWTPolicyConfiguration;
 import io.gravitee.policy.jwt.configuration.RevocationCheckConfiguration;
@@ -119,12 +117,6 @@ class JWTPolicyTest {
     private HttpPlainRequest request;
 
     @Mock
-    private HttpPlainResponse response;
-
-    @Mock
-    private HttpHeaders responseHeaders;
-
-    @Mock
     private RevocationChecker revocationChecker;
 
     private JWTPolicy cut;
@@ -140,9 +132,6 @@ class JWTPolicyTest {
     private void prepareClaimsSetCacheMocking() {
         lenient().when(ctx.getAttribute(ATTR_API)).thenReturn("API_ID");
         lenient().when(ctx.getAttribute(CONTEXT_ATTRIBUTE_JWT)).thenReturn(null);
-        lenient().when(ctx.response()).thenReturn(response);
-        lenient().when(response.headers()).thenReturn(responseHeaders);
-        lenient().when(configuration.isSendWwwAuthenticateHeader()).thenReturn(true);
     }
 
     private static Stream<Arguments> provideClientIdParameters() {
@@ -324,7 +313,6 @@ class JWTPolicyTest {
                 return true;
             })
         );
-        verify(responseHeaders).set("WWW-Authenticate", "Bearer error=\"invalid_token\", error_description=\"JWT token has been revoked\"");
     }
 
     @Test
@@ -348,7 +336,6 @@ class JWTPolicyTest {
                 return true;
             })
         );
-        verify(responseHeaders).set("WWW-Authenticate", "Bearer error=\"invalid_request\", error_description=\"Missing JWT token\"");
     }
 
     @Test
@@ -374,7 +361,6 @@ class JWTPolicyTest {
                 return true;
             })
         );
-        verify(responseHeaders).set("WWW-Authenticate", "Bearer error=\"invalid_request\", error_description=\"Missing JWT token\"");
     }
 
     @Test
@@ -400,7 +386,6 @@ class JWTPolicyTest {
                 return true;
             })
         );
-        verify(responseHeaders).set("WWW-Authenticate", "Bearer error=\"invalid_token\", error_description=\"Empty JWT token\"");
     }
 
     @Test
@@ -435,10 +420,6 @@ class JWTPolicyTest {
         );
 
         verify(metrics).setErrorMessage(MOCK_JOSE_EXCEPTION);
-        verify(responseHeaders).set(
-            "WWW-Authenticate",
-            "Bearer error=\"invalid_token\", error_description=\"" + MOCK_JOSE_EXCEPTION + "\""
-        );
     }
 
     @Test

--- a/src/test/java/io/gravitee/policy/v3/jwt/JWTPolicyV3Test.java
+++ b/src/test/java/io/gravitee/policy/v3/jwt/JWTPolicyV3Test.java
@@ -72,9 +72,6 @@ public abstract class JWTPolicyV3Test {
     private Response response;
 
     @Mock
-    private HttpHeaders responseHeaders;
-
-    @Mock
     private PolicyChain policyChain;
 
     @Mock
@@ -93,8 +90,6 @@ public abstract class JWTPolicyV3Test {
     private void prepareClaimsSetCacheMocking() {
         lenient().when(executionContext.getAttribute(ATTR_API)).thenReturn("API_ID");
         lenient().when(executionContext.getAttribute(CONTEXT_ATTRIBUTE_JWT)).thenReturn(null);
-        lenient().when(response.headers()).thenReturn(responseHeaders);
-        lenient().when(configuration.isSendWwwAuthenticateHeader()).thenReturn(true);
     }
 
     @Test
@@ -171,7 +166,6 @@ public abstract class JWTPolicyV3Test {
                 result -> result.statusCode() == HttpStatusCode.UNAUTHORIZED_401 && JWTPolicyV3.JWT_INVALID_TOKEN_KEY.equals(result.key())
             )
         );
-        verify(responseHeaders, times(1)).set(eq("WWW-Authenticate"), contains("error=\"invalid_token\""));
         verify(policyChain, never()).doNext(request, response);
     }
 
@@ -474,22 +468,6 @@ public abstract class JWTPolicyV3Test {
                 result -> result.statusCode() == HttpStatusCode.UNAUTHORIZED_401 && JWTPolicyV3.JWT_MISSING_TOKEN_KEY.equals(result.key())
             )
         );
-        verify(responseHeaders, times(1)).set(eq("WWW-Authenticate"), contains("error=\"invalid_request\""));
-    }
-
-    @Test
-    void test_not_authentification_empty_bearer_with_space() throws Exception {
-        HttpHeaders headers = HttpHeaders.create().set("Authorization", "Bearer ");
-        when(request.headers()).thenReturn(headers);
-
-        executePolicy(configuration, request, response, executionContext, policyChain);
-
-        verify(policyChain, times(1)).failWith(
-            argThat(
-                result -> result.statusCode() == HttpStatusCode.UNAUTHORIZED_401 && JWTPolicyV3.JWT_MISSING_TOKEN_KEY.equals(result.key())
-            )
-        );
-        verify(responseHeaders, times(1)).set(eq("WWW-Authenticate"), contains("error=\"invalid_request\""));
     }
 
     @Test
@@ -520,23 +498,6 @@ public abstract class JWTPolicyV3Test {
                 result -> result.statusCode() == HttpStatusCode.UNAUTHORIZED_401 && JWTPolicyV3.JWT_MISSING_TOKEN_KEY.equals(result.key())
             )
         );
-        verify(responseHeaders, times(1)).set(eq("WWW-Authenticate"), contains("error=\"invalid_request\""));
-    }
-
-    @Test
-    void test_should_not_set_www_authenticate_header_when_disabled() throws Exception {
-        HttpHeaders headers = HttpHeaders.create();
-        when(request.headers()).thenReturn(headers);
-        when(configuration.isSendWwwAuthenticateHeader()).thenReturn(false);
-
-        executePolicy(configuration, request, response, executionContext, policyChain);
-
-        verify(policyChain, times(1)).failWith(
-            argThat(
-                result -> result.statusCode() == HttpStatusCode.UNAUTHORIZED_401 && JWTPolicyV3.JWT_MISSING_TOKEN_KEY.equals(result.key())
-            )
-        );
-        verify(responseHeaders, never()).set(any(CharSequence.class), any(CharSequence.class));
     }
 
     @Test


### PR DESCRIPTION
Reverts gravitee-io/gravitee-policy-jwt#165

The approach for this fix needs to be reviewed. Hence reverting this PR.
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `7.0.3-revert-165-fix-APIM-13239-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/policy/gravitee-policy-jwt/7.0.3-revert-165-fix-APIM-13239-SNAPSHOT/gravitee-policy-jwt-7.0.3-revert-165-fix-APIM-13239-SNAPSHOT.zip)
  <!-- Version placeholder end -->
