### PR TITLE
feat(jwt): support dot-notation nested claim paths for clientIdClaim and userClaim

### DIFF
--- a/.docgen/usage.md
+++ b/.docgen/usage.md
@@ -34,3 +34,31 @@ You can extract the issuer from JWT using the following Expression Language stat
 
 <pre> {#context.attributes['jwt.claims']['iss']} </pre>
 
+### Nested claim extraction
+
+Both `clientIdClaim` and `userClaim` support dot-notation paths to extract values from nested JWT structures.
+
+Given the following JWT payload:
+
+```json
+{
+  "iss": "my-issuer",
+  "sub": "svc-account",
+  "act": {
+    "repository": "my-org/my-repo"
+  },
+  "realm_access": {
+    "preferred_username": "alice"
+  }
+}
+```
+
+Configure the policy as follows to resolve nested values:
+
+| Field | Value |
+|-------|-------|
+| `clientIdClaim` | `act.repository` → resolves to `my-org/my-repo` |
+| `userClaim` | `realm_access.preferred_username` → resolves to `alice` |
+
+**Flat-claim precedence:** If a JWT contains a top-level claim whose name literally includes a dot (e.g., `"act.repository": "flat-value"`), that flat claim takes precedence over any nested path traversal. This ensures full backward compatibility with existing tokens and configurations.
+

--- a/README.md
+++ b/README.md
@@ -66,6 +66,34 @@ You can extract the issuer from JWT using the following Expression Language stat
 
 <pre> {#context.attributes['jwt.claims']['iss']} </pre>
 
+### Nested claim extraction
+
+Both `clientIdClaim` and `userClaim` support dot-notation paths to extract values from nested JWT structures.
+
+Given the following JWT payload:
+
+```json
+{
+  "iss": "my-issuer",
+  "sub": "svc-account",
+  "act": {
+    "repository": "my-org/my-repo"
+  },
+  "realm_access": {
+    "preferred_username": "alice"
+  }
+}
+```
+
+Configure the policy as follows to resolve nested values:
+
+| Field | Value |
+|-------|-------|
+| `clientIdClaim` | `act.repository` → resolves to `my-org/my-repo` |
+| `userClaim` | `realm_access.preferred_username` → resolves to `alice` |
+
+**Flat-claim precedence:** If a JWT contains a top-level claim whose name literally includes a dot (e.g., `"act.repository": "flat-value"`), that flat claim takes precedence over any nested path traversal. This ensures full backward compatibility with existing tokens and configurations.
+
 
 
 
@@ -150,7 +178,7 @@ policy:
 #### 
 | Name <br>`json name`  | Type <br>`constraint`  | Mandatory  | Default  | Description  |
 |:----------------------|:-----------------------|:----------:|:---------|:-------------|
-| Client ID claim<br>`clientIdClaim`| string|  | | Claim where the client ID can be extracted. Configuring this field will override the standard behavior.|
+| Client ID claim<br>`clientIdClaim`| string|  | | Claim where the client ID can be extracted. Supports dot-notation for nested claims (e.g. 'act.repository'). A flat claim whose name literally contains a dot takes precedence. Configuring this field will override the standard behavior.|
 | Confirmation Method Validation<br>`confirmationMethodValidation`| object|  | | <br/>See "Confirmation Method Validation" section.|
 | JWKS URL connect timeout<br>`connectTimeout`| integer|  | `2000`| Only applies when the resolver is JWKS_URL|
 | Extract JWT Claims<br>`extractClaims`| boolean|  | | Put claims into the 'jwt.claims' context attribute.|
@@ -163,7 +191,7 @@ policy:
 | Signature<br>`signature`| enum (string)| ✅| `RSA_RS256`| Define how the JSON Web Token must be signed.<br>Values: `RSA_RS256` `RSA_RS384` `RSA_RS512` `HMAC_HS256` `HMAC_HS384` `HMAC_HS512`|
 | Token Type Validation<br>`tokenTypValidation`| object|  | | Define the token type to validate<br/>See "Token Type Validation" section.|
 | Use system proxy<br>`useSystemProxy`| boolean|  | | Use system proxy (make sense only when resolver is set to JWKS_URL)|
-| User claim<br>`userClaim`| string|  | `sub`| Claim where the user can be extracted|
+| User claim<br>`userClaim`| string|  | `sub`| Claim where the user can be extracted. Supports dot-notation for nested claims (e.g. 'realm_access.preferred_username'). A flat claim whose name literally contains a dot takes precedence.|
 
 
 #### Confirmation Method Validation (Object)

--- a/docs/POLICY_STUDIO_DOC.md
+++ b/docs/POLICY_STUDIO_DOC.md
@@ -57,6 +57,34 @@ You can extract the issuer from JWT using the following Expression Language stat
 
 <pre> {#context.attributes['jwt.claims']['iss']} </pre>
 
+### Nested claim extraction
+
+Both `clientIdClaim` and `userClaim` support dot-notation paths to extract values from nested JWT structures.
+
+Given the following JWT payload:
+
+```json
+{
+  "iss": "my-issuer",
+  "sub": "svc-account",
+  "act": {
+    "repository": "my-org/my-repo"
+  },
+  "realm_access": {
+    "preferred_username": "alice"
+  }
+}
+```
+
+Configure the policy as follows to resolve nested values:
+
+| Field | Value |
+|-------|-------|
+| `clientIdClaim` | `act.repository` → resolves to `my-org/my-repo` |
+| `userClaim` | `realm_access.preferred_username` → resolves to `alice` |
+
+**Flat-claim precedence:** If a JWT contains a top-level claim whose name literally includes a dot (e.g., `"act.repository": "flat-value"`), that flat claim takes precedence over any nested path traversal. This ensures full backward compatibility with existing tokens and configurations.
+
 
 
 

--- a/src/main/java/io/gravitee/policy/jwt/JWTPolicy.java
+++ b/src/main/java/io/gravitee/policy/jwt/JWTPolicy.java
@@ -42,6 +42,7 @@ import io.gravitee.policy.jwt.jwk.provider.JWTProcessorProvider;
 import io.gravitee.policy.jwt.jwk.source.JWKSUrlJWKSourceResolver;
 import io.gravitee.policy.jwt.revocation.RevocationChecker;
 import io.gravitee.policy.jwt.revocation.RevocationCheckerFactory;
+import io.gravitee.policy.jwt.utils.ClaimPathResolver;
 import io.gravitee.policy.jwt.utils.TokenExtractor;
 import io.gravitee.policy.processing.JWTClaimsSetValidator;
 import io.gravitee.policy.v3.jwt.JWTPolicyV3;
@@ -330,7 +331,7 @@ public class JWTPolicy extends JWTPolicyV3 implements HttpSecurityPolicy, KafkaS
 
         final String user;
         if (configuration.getUserClaim() != null && !configuration.getUserClaim().isEmpty()) {
-            user = (String) claims.getClaim(configuration.getUserClaim());
+            user = (String) ClaimPathResolver.resolve(claims, configuration.getUserClaim());
         } else {
             user = claims.getSubject();
         }

--- a/src/main/java/io/gravitee/policy/jwt/utils/ClaimPathResolver.java
+++ b/src/main/java/io/gravitee/policy/jwt/utils/ClaimPathResolver.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.policy.jwt.utils;
+
+import com.nimbusds.jwt.JWTClaimsSet;
+import java.util.Map;
+
+/**
+ * Resolves claim values from a {@link JWTClaimsSet} using dot-notation paths.
+ *
+ * <p>Resolution order:
+ * <ol>
+ *   <li><strong>Flat lookup first</strong> — {@code claims.getClaim(name)} is tried first.
+ *       If the result is non-null it is returned immediately. This preserves backward
+ *       compatibility for existing configurations whose claim name literally contains a
+ *       dot (e.g. {@code "x.y": "value"}).</li>
+ *   <li><strong>Nested walk</strong> — when the flat lookup returns {@code null} and the
+ *       name contains at least one {@code '.'}, the name is split on {@code '.'} and the
+ *       resolver walks successive {@link Map} values. Nimbus represents nested JSON objects
+ *       as {@code net.minidev.json.JSONObject}, which extends {@code Map<String, Object>}.</li>
+ *   <li>Returns {@code null} when any segment is missing, when an intermediate value is
+ *       not a {@link Map}, or when either argument is {@code null} / empty.</li>
+ * </ol>
+ *
+ * @author GraviteeSource Team
+ */
+public final class ClaimPathResolver {
+
+    private ClaimPathResolver() {}
+
+    /**
+     * Resolves a claim value from the given {@link JWTClaimsSet} using the supplied name.
+     * Supports dot-notation nested paths (e.g. {@code "act.repository"}).
+     *
+     * @param claims the JWT claims set to resolve from; may be {@code null}
+     * @param name   the claim name or dot-notation path; may be {@code null} or empty
+     * @return the resolved claim value, or {@code null} if not found
+     */
+    public static Object resolve(JWTClaimsSet claims, String name) {
+        if (claims == null || name == null || name.isEmpty()) {
+            return null;
+        }
+
+        // 1. Flat lookup — covers the common case and preserves backward compatibility
+        //    for claim names that literally contain a dot.
+        Object flatValue = claims.getClaim(name);
+        if (flatValue != null) {
+            return flatValue;
+        }
+
+        // 2. Nested walk — only attempted when the flat lookup misses and the name has dots.
+        if (!name.contains(".")) {
+            return null;
+        }
+
+        String[] segments = name.split("\\.", -1);
+
+        // First segment must resolve to a top-level claim.
+        Object current = claims.getClaim(segments[0]);
+
+        for (int i = 1; i < segments.length; i++) {
+            if (!(current instanceof Map<?, ?> map)) {
+                return null;
+            }
+            current = map.get(segments[i]);
+            if (current == null) {
+                return null;
+            }
+        }
+
+        return current;
+    }
+}

--- a/src/main/java/io/gravitee/policy/v3/jwt/JWTPolicyV3.java
+++ b/src/main/java/io/gravitee/policy/v3/jwt/JWTPolicyV3.java
@@ -31,6 +31,7 @@ import io.gravitee.policy.api.PolicyResult;
 import io.gravitee.policy.api.annotations.OnRequest;
 import io.gravitee.policy.jwt.alg.Signature;
 import io.gravitee.policy.jwt.configuration.JWTPolicyConfiguration;
+import io.gravitee.policy.jwt.utils.ClaimPathResolver;
 import io.gravitee.policy.jwt.utils.TokenExtractor;
 import io.gravitee.policy.processing.JWTClaimsSetValidator;
 import io.gravitee.policy.v3.jwt.exceptions.InvalidCertificateThumbprintException;
@@ -159,7 +160,7 @@ public class JWTPolicyV3 {
 
                         final String user;
                         if (configuration.getUserClaim() != null && !configuration.getUserClaim().isEmpty()) {
-                            user = (String) claims.getClaim(configuration.getUserClaim());
+                            user = (String) ClaimPathResolver.resolve(claims, configuration.getUserClaim());
                         } else {
                             user = claims.getSubject();
                         }
@@ -199,7 +200,7 @@ public class JWTPolicyV3 {
 
     protected String getClientId(JWTClaimsSet claims) {
         if (!ObjectUtils.isEmpty(configuration.getClientIdClaim())) {
-            Object clientIdClaim = claims.getClaim(configuration.getClientIdClaim());
+            Object clientIdClaim = ClaimPathResolver.resolve(claims, configuration.getClientIdClaim());
             return extractClientId(clientIdClaim);
         }
 

--- a/src/main/resources/schemas/schema-form.json
+++ b/src/main/resources/schemas/schema-form.json
@@ -132,13 +132,13 @@
         },
         "userClaim": {
             "title": "User claim",
-            "description": "Claim where the user can be extracted",
+            "description": "Claim where the user can be extracted. Supports dot-notation for nested claims (e.g. 'realm_access.preferred_username'). A flat claim whose name literally contains a dot takes precedence.",
             "type": "string",
             "default": "sub"
         },
         "clientIdClaim": {
             "title": "Client ID claim",
-            "description": "Claim where the client ID can be extracted. Configuring this field will override the standard behavior.",
+            "description": "Claim where the client ID can be extracted. Supports dot-notation for nested claims (e.g. 'act.repository'). A flat claim whose name literally contains a dot takes precedence. Configuring this field will override the standard behavior.",
             "type": "string"
         },
         "confirmationMethodValidation": {

--- a/src/test/java/io/gravitee/policy/jwt/JWTPolicyTest.java
+++ b/src/test/java/io/gravitee/policy/jwt/JWTPolicyTest.java
@@ -67,6 +67,7 @@ import java.util.Collections;
 import java.util.Date;
 import java.util.List;
 import java.util.stream.Stream;
+import net.minidev.json.JSONObject;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -483,6 +484,101 @@ class JWTPolicyTest {
         final TestObserver<SecurityToken> obs = cut.extractSecurityToken(ctx).test();
 
         obs.assertComplete().assertValueCount(0);
+    }
+
+    @Test
+    void should_resolve_nested_clientid_claim_in_v4_path() throws BadJOSEException, JOSEException {
+        final Metrics metrics = mock(Metrics.class);
+        final HttpHeaders headers = mock(HttpHeaders.class);
+
+        // JWT payload: nested act and repository
+        JSONObject act = new JSONObject();
+        act.put("repository", "dktunited/poc-github-fedid-token-exchange");
+
+        final JWTClaimsSet claimsSet = new JWTClaimsSet.Builder()
+            .issuer(ISSUER)
+            .subject(STANDARD_SUBJECT)
+            .claim("act", act)
+            .expirationTime(new Date(System.currentTimeMillis() + 3600000))
+            .build();
+
+        when(configuration.getClientIdClaim()).thenReturn("act.repository");
+        when(headers.getAll(HttpHeaderNames.AUTHORIZATION)).thenReturn(List.of("Bearer " + TOKEN));
+        when(jwtProcessorResolver.provide(ctx)).thenReturn(Maybe.just(jwtProcessor));
+        when(jwtProcessor.process(any(JWT.class), isNull())).thenReturn(claimsSet);
+        when(ctx.request()).thenReturn(request);
+        when(ctx.metrics()).thenReturn(metrics);
+        when(ctx.getAttribute(CONTEXT_ATTRIBUTE_OAUTH_CLIENT_ID)).thenReturn("dktunited/poc-github-fedid-token-exchange");
+        when(ctx.getAttribute(ATTR_USER)).thenReturn(STANDARD_SUBJECT);
+        when(request.headers()).thenReturn(headers);
+
+        final TestObserver<Void> obs = cut.onRequest(ctx).test();
+        obs.assertComplete();
+
+        verify(ctx).setAttribute(CONTEXT_ATTRIBUTE_OAUTH_CLIENT_ID, "dktunited/poc-github-fedid-token-exchange");
+    }
+
+    @Test
+    void should_resolve_nested_user_claim_in_v4_path() throws BadJOSEException, JOSEException {
+        final Metrics metrics = mock(Metrics.class);
+        final HttpHeaders headers = mock(HttpHeaders.class);
+
+        // JWT payload: nested realm_access and preferred_username
+        JSONObject realmAccess = new JSONObject();
+        realmAccess.put("preferred_username", "john.doe");
+
+        final JWTClaimsSet claimsSet = new JWTClaimsSet.Builder()
+            .issuer(ISSUER)
+            .subject(STANDARD_SUBJECT)
+            .claim(CLIENT_ID, CLIENT_ID)
+            .claim("realm_access", realmAccess)
+            .expirationTime(new Date(System.currentTimeMillis() + 3600000))
+            .build();
+
+        when(configuration.getUserClaim()).thenReturn("realm_access.preferred_username");
+        when(headers.getAll(HttpHeaderNames.AUTHORIZATION)).thenReturn(List.of("Bearer " + TOKEN));
+        when(jwtProcessorResolver.provide(ctx)).thenReturn(Maybe.just(jwtProcessor));
+        when(jwtProcessor.process(any(JWT.class), isNull())).thenReturn(claimsSet);
+        when(ctx.request()).thenReturn(request);
+        when(ctx.metrics()).thenReturn(metrics);
+        when(ctx.getAttribute(CONTEXT_ATTRIBUTE_OAUTH_CLIENT_ID)).thenReturn(CLIENT_ID);
+        when(ctx.getAttribute(ATTR_USER)).thenReturn("john.doe");
+        when(request.headers()).thenReturn(headers);
+
+        final TestObserver<Void> obs = cut.onRequest(ctx).test();
+        obs.assertComplete();
+
+        verify(ctx).setAttribute(ATTR_USER, "john.doe");
+    }
+
+    @Test
+    void should_resolve_flat_user_claim_when_literal_dot_name_exists_in_v4_path() throws BadJOSEException, JOSEException {
+        final Metrics metrics = mock(Metrics.class);
+        final HttpHeaders headers = mock(HttpHeaders.class);
+
+        // A top-level claim whose name literally contains a dot must win over nested resolution.
+        final JWTClaimsSet claimsSet = new JWTClaimsSet.Builder()
+            .issuer(ISSUER)
+            .subject(STANDARD_SUBJECT)
+            .claim(CLIENT_ID, CLIENT_ID)
+            .claim("x.y", "flat-user-value")
+            .expirationTime(new Date(System.currentTimeMillis() + 3600000))
+            .build();
+
+        when(configuration.getUserClaim()).thenReturn("x.y");
+        when(headers.getAll(HttpHeaderNames.AUTHORIZATION)).thenReturn(List.of("Bearer " + TOKEN));
+        when(jwtProcessorResolver.provide(ctx)).thenReturn(Maybe.just(jwtProcessor));
+        when(jwtProcessor.process(any(JWT.class), isNull())).thenReturn(claimsSet);
+        when(ctx.request()).thenReturn(request);
+        when(ctx.metrics()).thenReturn(metrics);
+        when(ctx.getAttribute(CONTEXT_ATTRIBUTE_OAUTH_CLIENT_ID)).thenReturn(CLIENT_ID);
+        when(ctx.getAttribute(ATTR_USER)).thenReturn("flat-user-value");
+        when(request.headers()).thenReturn(headers);
+
+        final TestObserver<Void> obs = cut.onRequest(ctx).test();
+        obs.assertComplete();
+
+        verify(ctx).setAttribute(ATTR_USER, "flat-user-value");
     }
 
     private void verifyMetricsAttributesAndHeaders(Metrics metrics, HttpHeaders headers, String expectedClientId, String expectedSubject) {

--- a/src/test/java/io/gravitee/policy/jwt/utils/ClaimPathResolverTest.java
+++ b/src/test/java/io/gravitee/policy/jwt/utils/ClaimPathResolverTest.java
@@ -1,0 +1,202 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.policy.jwt.utils;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.nimbusds.jwt.JWTClaimsSet;
+import java.util.Date;
+import net.minidev.json.JSONObject;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit tests for {@link ClaimPathResolver}.
+ *
+ * @author GraviteeSource Team
+ */
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class ClaimPathResolverTest {
+
+    // -----------------------------------------------------------------------
+    // Nested hit
+    // -----------------------------------------------------------------------
+
+    @Test
+    void should_resolve_nested_claim_with_dot_notation() {
+        JSONObject act = new JSONObject();
+        act.put("repository", "myorg/my-repo");
+
+        JWTClaimsSet claims = new JWTClaimsSet.Builder()
+            .subject("sub")
+            .expirationTime(new Date(System.currentTimeMillis() + 60_000))
+            .claim("act", act)
+            .build();
+
+        Object result = ClaimPathResolver.resolve(claims, "act.repository");
+
+        assertThat(result).isEqualTo("myorg/my-repo");
+    }
+
+    @Test
+    void should_resolve_deeply_nested_claim() {
+        JSONObject inner = new JSONObject();
+        inner.put("id", "deep-value");
+
+        JSONObject outer = new JSONObject();
+        outer.put("inner", inner);
+
+        JWTClaimsSet claims = new JWTClaimsSet.Builder()
+            .subject("sub")
+            .expirationTime(new Date(System.currentTimeMillis() + 60_000))
+            .claim("outer", outer)
+            .build();
+
+        Object result = ClaimPathResolver.resolve(claims, "outer.inner.id");
+
+        assertThat(result).isEqualTo("deep-value");
+    }
+
+    // -----------------------------------------------------------------------
+    // Flat hit (no dot in name)
+    // -----------------------------------------------------------------------
+
+    @Test
+    void should_resolve_flat_top_level_claim() {
+        JWTClaimsSet claims = new JWTClaimsSet.Builder()
+            .subject("alexluso")
+            .expirationTime(new Date(System.currentTimeMillis() + 60_000))
+            .claim("client_id", "my-client")
+            .build();
+
+        Object result = ClaimPathResolver.resolve(claims, "client_id");
+
+        assertThat(result).isEqualTo("my-client");
+    }
+
+    // -----------------------------------------------------------------------
+    // Flat-with-literal-dot wins over nested walk (flat-first fallback)
+    // -----------------------------------------------------------------------
+
+    @Test
+    void should_return_flat_claim_when_literal_dot_name_exists_at_top_level() {
+        // A claim whose name literally contains a dot must win over nested resolution.
+        JWTClaimsSet claims = new JWTClaimsSet.Builder()
+            .subject("sub")
+            .expirationTime(new Date(System.currentTimeMillis() + 60_000))
+            .claim("x.y", "flat-value")
+            .build();
+
+        Object result = ClaimPathResolver.resolve(claims, "x.y");
+
+        assertThat(result).isEqualTo("flat-value");
+    }
+
+    // -----------------------------------------------------------------------
+    // Missing mid-path
+    // -----------------------------------------------------------------------
+
+    @Test
+    void should_return_null_when_intermediate_segment_is_missing() {
+        JSONObject act = new JSONObject();
+        act.put("repository", "myorg/my-repo");
+
+        JWTClaimsSet claims = new JWTClaimsSet.Builder()
+            .subject("sub")
+            .expirationTime(new Date(System.currentTimeMillis() + 60_000))
+            .claim("act", act)
+            .build();
+
+        Object result = ClaimPathResolver.resolve(claims, "act.missing.field");
+
+        assertThat(result).isNull();
+    }
+
+    @Test
+    void should_return_null_when_first_segment_does_not_exist() {
+        JWTClaimsSet claims = new JWTClaimsSet.Builder()
+            .subject("sub")
+            .expirationTime(new Date(System.currentTimeMillis() + 60_000))
+            .build();
+
+        Object result = ClaimPathResolver.resolve(claims, "nonexistent.field");
+
+        assertThat(result).isNull();
+    }
+
+    // -----------------------------------------------------------------------
+    // Non-Map mid-path
+    // -----------------------------------------------------------------------
+
+    @Test
+    void should_return_null_when_intermediate_value_is_not_a_map() {
+        JWTClaimsSet claims = new JWTClaimsSet.Builder()
+            .subject("alexluso") // subject is a String, not a Map
+            .expirationTime(new Date(System.currentTimeMillis() + 60_000))
+            .build();
+
+        // "sub" is a String, so walking "sub.nested" must return null.
+        Object result = ClaimPathResolver.resolve(claims, "sub.nested");
+
+        assertThat(result).isNull();
+    }
+
+    // -----------------------------------------------------------------------
+    // Null / empty guard conditions
+    // -----------------------------------------------------------------------
+
+    @Test
+    void should_return_null_when_claims_is_null() {
+        assertThat(ClaimPathResolver.resolve(null, "act.repository")).isNull();
+    }
+
+    @Test
+    void should_return_null_when_name_is_null() {
+        JWTClaimsSet claims = new JWTClaimsSet.Builder()
+            .subject("sub")
+            .expirationTime(new Date(System.currentTimeMillis() + 60_000))
+            .build();
+
+        assertThat(ClaimPathResolver.resolve(claims, null)).isNull();
+    }
+
+    @Test
+    void should_return_null_when_name_is_empty() {
+        JWTClaimsSet claims = new JWTClaimsSet.Builder()
+            .subject("sub")
+            .expirationTime(new Date(System.currentTimeMillis() + 60_000))
+            .build();
+
+        assertThat(ClaimPathResolver.resolve(claims, "")).isNull();
+    }
+
+    // -----------------------------------------------------------------------
+    // Back-compat: standard flat claim name (no dot) still resolves
+    // -----------------------------------------------------------------------
+
+    @Test
+    void should_resolve_standard_sub_claim() {
+        JWTClaimsSet claims = new JWTClaimsSet.Builder()
+            .subject("john.doe@example.com")
+            .expirationTime(new Date(System.currentTimeMillis() + 60_000))
+            .build();
+
+        Object result = ClaimPathResolver.resolve(claims, "sub");
+
+        assertThat(result).isEqualTo("john.doe@example.com");
+    }
+}

--- a/src/test/java/io/gravitee/policy/v3/jwt/JWTPolicyV3Test.java
+++ b/src/test/java/io/gravitee/policy/v3/jwt/JWTPolicyV3Test.java
@@ -16,6 +16,7 @@
 package io.gravitee.policy.v3.jwt;
 
 import static io.gravitee.gateway.api.ExecutionContext.ATTR_API;
+import static io.gravitee.gateway.api.ExecutionContext.ATTR_USER;
 import static io.gravitee.policy.jwt.JWTPolicy.CONTEXT_ATTRIBUTE_JWT;
 import static org.mockito.Mockito.*;
 
@@ -41,6 +42,7 @@ import java.util.Collections;
 import java.util.Date;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
+import net.minidev.json.JSONObject;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -212,6 +214,103 @@ public abstract class JWTPolicyV3Test {
 
         verify(executionContext, times(1)).setAttribute(JWTPolicyV3.CONTEXT_ATTRIBUTE_OAUTH_CLIENT_ID, "my-client-id-from-configuration");
 
+        verify(policyChain, times(1)).doNext(request, response);
+    }
+
+    @Test
+    void test_get_client_with_nested_clientid_claim() throws Exception {
+        when(executionContext.getComponent(Environment.class)).thenReturn(environment);
+        when(environment.getProperty("policy.jwt.issuer.gravitee.authorization.server.MAIN")).thenReturn(getSignatureKey());
+
+        // Build a JWT with a nested "act" claim containing "repository".
+        JSONObject act = new JSONObject();
+        act.put("repository", "dktunited/poc-github-fedid-token-exchange");
+
+        JWTClaimsSet.Builder builder = getJsonWebTokenBuilder(7200);
+        builder.claim("act", act);
+
+        String jwt = sign(builder.build());
+
+        HttpHeaders headers = HttpHeaders.create().set("Authorization", "Bearer " + jwt);
+        when(request.headers()).thenReturn(headers);
+        when(configuration.getPublicKeyResolver()).thenReturn(KeyResolver.GATEWAY_KEYS);
+        when(configuration.getClientIdClaim()).thenReturn("act.repository");
+
+        executePolicy(configuration, request, response, executionContext, policyChain);
+
+        verify(executionContext, times(1)).setAttribute(
+            JWTPolicyV3.CONTEXT_ATTRIBUTE_OAUTH_CLIENT_ID,
+            "dktunited/poc-github-fedid-token-exchange"
+        );
+        verify(policyChain, times(1)).doNext(request, response);
+    }
+
+    @Test
+    void test_get_client_with_literal_dot_clientid_claim_flat_wins() throws Exception {
+        when(executionContext.getComponent(Environment.class)).thenReturn(environment);
+        when(environment.getProperty("policy.jwt.issuer.gravitee.authorization.server.MAIN")).thenReturn(getSignatureKey());
+
+        // A top-level claim whose name literally contains a dot must win over nested resolution.
+        JWTClaimsSet.Builder builder = getJsonWebTokenBuilder(7200);
+        builder.claim("x.y", "flat-value");
+
+        String jwt = sign(builder.build());
+
+        HttpHeaders headers = HttpHeaders.create().set("Authorization", "Bearer " + jwt);
+        when(request.headers()).thenReturn(headers);
+        when(configuration.getPublicKeyResolver()).thenReturn(KeyResolver.GATEWAY_KEYS);
+        when(configuration.getClientIdClaim()).thenReturn("x.y");
+
+        executePolicy(configuration, request, response, executionContext, policyChain);
+
+        verify(executionContext, times(1)).setAttribute(JWTPolicyV3.CONTEXT_ATTRIBUTE_OAUTH_CLIENT_ID, "flat-value");
+        verify(policyChain, times(1)).doNext(request, response);
+    }
+
+    @Test
+    void test_get_user_with_nested_user_claim() throws Exception {
+        when(executionContext.getComponent(Environment.class)).thenReturn(environment);
+        when(environment.getProperty("policy.jwt.issuer.gravitee.authorization.server.MAIN")).thenReturn(getSignatureKey());
+
+        // JWT payload: nested realm_access and preferred_username
+        JSONObject realmAccess = new JSONObject();
+        realmAccess.put("preferred_username", "john.doe");
+
+        JWTClaimsSet.Builder builder = getJsonWebTokenBuilder(7200);
+        builder.claim("realm_access", realmAccess);
+
+        String jwt = sign(builder.build());
+
+        HttpHeaders headers = HttpHeaders.create().set("Authorization", "Bearer " + jwt);
+        when(request.headers()).thenReturn(headers);
+        when(configuration.getPublicKeyResolver()).thenReturn(KeyResolver.GATEWAY_KEYS);
+        when(configuration.getUserClaim()).thenReturn("realm_access.preferred_username");
+
+        executePolicy(configuration, request, response, executionContext, policyChain);
+
+        verify(executionContext, times(1)).setAttribute(ATTR_USER, "john.doe");
+        verify(policyChain, times(1)).doNext(request, response);
+    }
+
+    @Test
+    void test_get_user_with_literal_dot_user_claim_flat_wins() throws Exception {
+        when(executionContext.getComponent(Environment.class)).thenReturn(environment);
+        when(environment.getProperty("policy.jwt.issuer.gravitee.authorization.server.MAIN")).thenReturn(getSignatureKey());
+
+        // A top-level claim whose name literally contains a dot must win over nested resolution.
+        JWTClaimsSet.Builder builder = getJsonWebTokenBuilder(7200);
+        builder.claim("x.y", "flat-user-value");
+
+        String jwt = sign(builder.build());
+
+        HttpHeaders headers = HttpHeaders.create().set("Authorization", "Bearer " + jwt);
+        when(request.headers()).thenReturn(headers);
+        when(configuration.getPublicKeyResolver()).thenReturn(KeyResolver.GATEWAY_KEYS);
+        when(configuration.getUserClaim()).thenReturn("x.y");
+
+        executePolicy(configuration, request, response, executionContext, policyChain);
+
+        verify(executionContext, times(1)).setAttribute(ATTR_USER, "flat-user-value");
         verify(policyChain, times(1)).doNext(request, response);
     }
 


### PR DESCRIPTION

## Issue

https://gravitee.atlassian.net/browse/APIM-13713
## Description

## Description
[APIM-13713](https://gravitee.atlassian.net/browse/APIM-13713) (Parent: [APIM-12450](https://gravitee.atlassian.net/browse/APIM-12450))

This PR introduces support for resolving nested JSON claims in JWT tokens using dot-notation syntax (e.g., `act.repository`), allowing users to extract client IDs and user information from complex, nested JWT structures.

**Key Changes:**
- Introduced `ClaimPathResolver` to handle recursive `Map` navigation for dot-notation paths.
- Updated `JWTPolicyV3` (`getClientId` and `userClaim` extraction) and `JWTPolicy` v4 (`setAuthContextInfos`) to leverage the new resolver.
- **Backward Compatibility:** Implemented a "flat-first" lookup strategy. The policy attempts to resolve the exact string match first, ensuring that existing configurations relying on claim names that *literally* contain a dot (e.g., `"x.y": "value"`) continue to function without disruption.
- Updated `schema-form.json` and `README.md` to document the new behavior and provide examples.
- Comprehensive unit and integration test coverage for both flat and nested claim resolutions.

## Testing Instructions
To verify this locally:

1. **Setup API and Application:**
   - Create a dummy API protected by the JWT Policy.
   - Configure the policy with `clientIdClaim` set to `act.repository`.
   - Create an Application (e.g., "Nested Claim App") with its `client_id` manually set to `abcd`.
   - Subscribe the Application to the API and **approve** the subscription.

2. **Test Baseline (Flat Claim):**
   - Generate a JWT with a flat claim: `"act.repository": "abdc"` (using a site like jwt.io and your gateway's shared secret).
   - `curl -v -H "Authorization: Bearer <FLAT_JWT>" http://localhost:8082/<api-context-path>`
   - **Expected:** `200 OK` (Verifies backward compatibility).

3. **Test Fix (Nested Claim):**
   - Generate a JWT with a nested claim structure:
     ```json
     {
       "act": {
         "repository": "abcd"
       }
     }
     ```
   - `curl -v -H "Authorization: Bearer <NESTED_JWT>" http://localhost:8082/<api-context-path>`
   - **Expected:** `200 OK` (Verifies nested dot-notation resolution).


[APIM-13713]: https://gravitee.atlassian.net/browse/APIM-13713?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[APIM-12450]: https://gravitee.atlassian.net/browse/APIM-12450?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `7.1.0-fix-APIM-13713-nested-claim-path-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/policy/gravitee-policy-jwt/7.1.0-fix-APIM-13713-nested-claim-path-SNAPSHOT/gravitee-policy-jwt-7.1.0-fix-APIM-13713-nested-claim-path-SNAPSHOT.zip)
  <!-- Version placeholder end -->
