### PR TITLE
Update project to use vert.x 5

### DIFF
--- a/.docgen/matrix.yaml
+++ b/.docgen/matrix.yaml
@@ -1,7 +1,10 @@
 rows:
     - data:
+          plugin: "8.x"
+          apim: "4.12.x to latest"
+    - data:
           plugin: "7.x"
-          apim: "4.9.x to latest"
+          apim: "4.9.x to 4.11.x"
     - data:
           plugin: "6.x"
           apim: "4.6.x to 4.8.x"

--- a/README.md
+++ b/README.md
@@ -100,7 +100,8 @@ Strikethrough text indicates that a version is deprecated.
 
 | Plugin version| APIM |
 | --- | ---  |
-|7.x|4.9.x to latest |
+|8.x|4.12.x to latest |
+|7.x|4.9.x to 4.11.x |
 |6.x|4.6.x to 4.8.x |
 |5.x|4.4.x to 4.5.x |
 |4.x|4.0.x to 4.3.x |

--- a/pom.xml
+++ b/pom.xml
@@ -34,10 +34,9 @@
     </parent>
 
     <properties>
-        <gravitee-apim.version>4.11.4</gravitee-apim.version>
+        <gravitee-apim.version>4.12.0-SNAPSHOT</gravitee-apim.version>
 
         <sshj.version>0.40.0</sshj.version>
-        <maven-plugin-assembly.version>3.8.0</maven-plugin-assembly.version>
         <maven-plugin-properties.version>1.3.0</maven-plugin-properties.version>
 
         <!-- Property used by the publication job in CI-->
@@ -211,7 +210,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-assembly-plugin</artifactId>
-                <version>${maven-plugin-assembly.version}</version>
                 <configuration>
                     <appendAssemblyId>false</appendAssemblyId>
                     <descriptors>

--- a/src/main/java/io/gravitee/policy/jwt/contentretriever/vertx/authentication/BasicAuthenticationHandler.java
+++ b/src/main/java/io/gravitee/policy/jwt/contentretriever/vertx/authentication/BasicAuthenticationHandler.java
@@ -42,7 +42,7 @@ public class BasicAuthenticationHandler implements AuthenticationHandler {
         String credentials = username + ":" + password;
         String encodedCredentials = Base64.getEncoder().encodeToString(credentials.getBytes(StandardCharsets.UTF_8));
 
-        MultiMap headers = new HeadersMultiMap();
+        MultiMap headers = HeadersMultiMap.httpHeaders();
         headers.add(HttpHeaders.AUTHORIZATION.toString(), "Basic " + encodedCredentials);
         return headers;
     }

--- a/src/main/java/io/gravitee/policy/jwt/contentretriever/vertx/authentication/BearerTokenAuthenticationHandler.java
+++ b/src/main/java/io/gravitee/policy/jwt/contentretriever/vertx/authentication/BearerTokenAuthenticationHandler.java
@@ -32,7 +32,7 @@ public class BearerTokenAuthenticationHandler implements AuthenticationHandler {
 
     @Override
     public MultiMap getAuthenticationHeaders() {
-        MultiMap headers = new HeadersMultiMap();
+        MultiMap headers = HeadersMultiMap.httpHeaders();
         headers.add(HttpHeaders.AUTHORIZATION.toString(), "Bearer " + token);
         return headers;
     }

--- a/src/main/java/io/gravitee/policy/v3/jwt/jwks/retriever/VertxResourceRetriever.java
+++ b/src/main/java/io/gravitee/policy/v3/jwt/jwks/retriever/VertxResourceRetriever.java
@@ -111,7 +111,7 @@ public class VertxResourceRetriever implements ResourceRetriever {
                 httpClient.close();
             });
         } else {
-            httpResponse.end(event -> httpClient.close());
+            httpResponse.endHandler(event -> httpClient.close()).end();
             promise.fail("Status code from JWKS URL is not valid: " + httpResponse.statusCode());
         }
     }

--- a/src/test/java/io/gravitee/policy/jwt/JwtPolicyV4EmulationEngineCnfIntegrationTest.java
+++ b/src/test/java/io/gravitee/policy/jwt/JwtPolicyV4EmulationEngineCnfIntegrationTest.java
@@ -48,7 +48,9 @@ import io.gravitee.policy.jwt.configuration.JWTPolicyConfiguration;
 import io.reactivex.rxjava3.core.Single;
 import io.vertx.core.http.HttpClientOptions;
 import io.vertx.core.http.HttpMethod;
+import io.vertx.core.http.PoolOptions;
 import io.vertx.core.net.PemKeyCertOptions;
+import io.vertx.core.net.SSLEngineOptions;
 import io.vertx.rxjava3.core.http.HttpClient;
 import io.vertx.rxjava3.core.http.HttpClientResponse;
 import java.net.URLEncoder;
@@ -180,6 +182,7 @@ public class JwtPolicyV4EmulationEngineCnfIntegrationTest {
         @Override
         protected void configureHttpClient(
             final HttpClientOptions options,
+            PoolOptions poolOptions,
             GatewayDynamicConfig.Config gatewayConfig,
             ParameterContext parameterContext
         ) {
@@ -254,6 +257,7 @@ public class JwtPolicyV4EmulationEngineCnfIntegrationTest {
         @Override
         protected void configureHttpClient(
             final HttpClientOptions options,
+            PoolOptions poolOptions,
             GatewayDynamicConfig.Config gatewayConfig,
             ParameterContext parameterContext
         ) {
@@ -370,6 +374,7 @@ public class JwtPolicyV4EmulationEngineCnfIntegrationTest {
         @Override
         protected void configureHttpClient(
             final HttpClientOptions options,
+            PoolOptions poolOptions,
             GatewayDynamicConfig.Config gatewayConfig,
             ParameterContext parameterContext
         ) {
@@ -382,7 +387,7 @@ public class JwtPolicyV4EmulationEngineCnfIntegrationTest {
             pemKeyCertOptions.setKeyPath(
                 JwtPolicyV4EmulationEngineCnfIntegrationTest.class.getResource("/client/client1-key.pem").getPath()
             );
-            options.setPemKeyCertOptions(pemKeyCertOptions);
+            options.getSslOptions().setKeyCertOptions(pemKeyCertOptions);
         }
 
         @Override
@@ -475,6 +480,7 @@ public class JwtPolicyV4EmulationEngineCnfIntegrationTest {
         @Override
         protected void configureHttpClient(
             final HttpClientOptions options,
+            PoolOptions poolOptions,
             GatewayDynamicConfig.Config gatewayConfig,
             ParameterContext parameterContext
         ) {


### PR DESCRIPTION
## Description

BREAKING CHANGE: requires APIM 4.12 and Vert.x 5
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `8.0.0-use-vertx-5-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/policy/gravitee-policy-jwt/8.0.0-use-vertx-5-SNAPSHOT/gravitee-policy-jwt-8.0.0-use-vertx-5-SNAPSHOT.zip)
  <!-- Version placeholder end -->
