### PR TITLE
fix: disabled token validation with typ jws

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ policy:
 | Resolver parameter<br>`resolverParameter`| string|  | | Set the signature key GIVEN_KEY or a JWKS_URL following selected resolver (support EL).|
 | Revocation Check<br>`revocationCheck`| object|  | | Define revocation check details. If enabled, will check the configured claim of the token against a cached revocation list and deny if a match is found. Disabled by default.<br/>See "Revocation Check" section.|
 | Signature<br>`signature`| enum (string)| ✅| `RSA_RS256`| Define how the JSON Web Token must be signed.<br>Values: `RSA_RS256` `RSA_RS384` `RSA_RS512` `HMAC_HS256` `HMAC_HS384` `HMAC_HS512`|
-| Token Type Validation<br>`tokenTypValidation`| object|  | | Define the token type to validate<br/>See "Token Type Validation" section.|
+| Token Type Validation<br>`tokenTypValidation`| object|  | | Define the token type to validate. When disabled (the default), the typ header is not validated.<br/>See "Token Type Validation" section.|
 | Use system proxy<br>`useSystemProxy`| boolean|  | | Use system proxy (make sense only when resolver is set to JWKS_URL)|
 | User claim<br>`userClaim`| string|  | `sub`| Claim where the user can be extracted|
 
@@ -235,10 +235,10 @@ policy:
 #### Token Type Validation (Object)
 | Name <br>`json name`  | Type <br>`constraint`  | Mandatory  | Default  | Description  |
 |:----------------------|:-----------------------|:----------:|:---------|:-------------|
-| Enable token type validation<br>`enabled`| boolean|  | | Will validate the token type extracted from the access_token with the one provided by the client. The default is false.|
-| Expected values<br>`expectedValues`| array (string)|  | `[JWT]`| List of expected token types. If the token type is not in the list, the validation will fail.|
-| Ignore case<br>`ignoreCase`| boolean|  | | Will ignore the case of the token type when comparing the expected values. Default is false.|
-| Ignore missing token type<br>`ignoreMissing`| boolean|  | | Will ignore token type validation if the token doesn't contain any token type information. Default is false.|
+| Enable token type validation<br>`enabled`| boolean|  | | When true, validates the token typ header against expected values. When disabled, the typ header is not validated and expectedValues is ignored.|
+| Expected values<br>`expectedValues`| array (string)|  | `[JWT]`| Only applies when token type validation is enabled. List of expected token types. If the token type is not in the list, the validation will fail.|
+| Ignore case<br>`ignoreCase`| boolean|  | | Only applies when token type validation is enabled. Will ignore the case of the token type when comparing the expected values. Default is false.|
+| Ignore missing token type<br>`ignoreMissing`| boolean|  | | Only applies when token type validation is enabled. Will ignore token type validation if the token doesn't contain any token type information. Default is false.|
 
 
 

--- a/src/main/java/io/gravitee/policy/jwt/utils/TokenTypeVerifierFactory.java
+++ b/src/main/java/io/gravitee/policy/jwt/utils/TokenTypeVerifierFactory.java
@@ -26,6 +26,8 @@ import lombok.experimental.UtilityClass;
 @UtilityClass
 public class TokenTypeVerifierFactory {
 
+    private static final JOSEObjectTypeVerifier<SecurityContext> PERMISSIVE_VERIFIER = (type, context) -> {};
+
     public JOSEObjectTypeVerifier<SecurityContext> buildCustom(JWTPolicyConfiguration.TokenTypValidation tokenTypValidation) {
         return (header, context) -> {
             String typ = header.getType() != null ? header.getType() : null;
@@ -45,20 +47,14 @@ public class TokenTypeVerifierFactory {
         };
     }
 
-    public DefaultJOSEObjectTypeVerifier<SecurityContext> buildDefault() {
-        return new DefaultJOSEObjectTypeVerifier<>(
-            JOSEObjectType.JWT,
-            new JOSEObjectType("at+jwt"),
-            new JOSEObjectType("application/at+jwt"),
-            null
-        );
+    public JOSEObjectTypeVerifier<SecurityContext> buildPermissive() {
+        return PERMISSIVE_VERIFIER;
     }
 
     public JOSEObjectTypeVerifier<SecurityContext> build(JWTPolicyConfiguration.TokenTypValidation tokenTypValidation) {
         if (tokenTypValidation == null || !tokenTypValidation.isEnabled()) {
-            return buildDefault();
-        } else {
-            return buildCustom(tokenTypValidation);
+            return buildPermissive();
         }
+        return buildCustom(tokenTypValidation);
     }
 }

--- a/src/main/resources/schemas/schema-form.json
+++ b/src/main/resources/schemas/schema-form.json
@@ -180,24 +180,24 @@
         },
         "tokenTypValidation": {
             "title": "Token Type Validation",
-            "description": "Define the token type to validate",
+            "description": "Define the token type to validate. When disabled (the default), the typ header is not validated.",
             "type": "object",
             "properties": {
                 "enabled": {
                     "title": "Enable token type validation",
-                    "description": "Will validate the token type extracted from the access_token with the one provided by the client. The default is false.",
+                    "description": "When true, validates the token typ header against expected values. When disabled, the typ header is not validated and expectedValues is ignored.",
                     "type": "boolean",
                     "default": false
                 },
                 "ignoreMissing": {
                     "title": "Ignore missing token type",
-                    "description": "Will ignore token type validation if the token doesn't contain any token type information. Default is false.",
+                    "description": "Only applies when token type validation is enabled. Will ignore token type validation if the token doesn't contain any token type information. Default is false.",
                     "type": "boolean",
                     "default": false
                 },
                 "expectedValues": {
                     "title": "Expected values",
-                    "description": "List of expected token types. If the token type is not in the list, the validation will fail.",
+                    "description": "Only applies when token type validation is enabled. List of expected token types. If the token type is not in the list, the validation will fail.",
                     "type": "array",
                     "items": {
                         "type": "string"
@@ -206,7 +206,7 @@
                 },
                 "ignoreCase": {
                     "title": "Ignore case",
-                    "description": "Will ignore the case of the token type when comparing the expected values. Default is false.",
+                    "description": "Only applies when token type validation is enabled. Will ignore the case of the token type when comparing the expected values. Default is false.",
                     "type": "boolean",
                     "default": false
                 }

--- a/src/test/java/io/gravitee/policy/jwt/JwtPolicyV4EmulationEngineDisabledTokenTypIntegrationTest.java
+++ b/src/test/java/io/gravitee/policy/jwt/JwtPolicyV4EmulationEngineDisabledTokenTypIntegrationTest.java
@@ -1,0 +1,183 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.policy.jwt;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.getRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.ok;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
+import static io.gravitee.policy.jwt.alg.Signature.HMAC_HS256;
+import static io.gravitee.policy.v3.jwt.resolver.KeyResolver.GIVEN_KEY;
+import static io.vertx.core.http.HttpMethod.GET;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.nimbusds.jose.JOSEObjectType;
+import com.nimbusds.jose.JWSHeader;
+import com.nimbusds.jose.crypto.MACSigner;
+import com.nimbusds.jwt.JWTClaimsSet;
+import com.nimbusds.jwt.SignedJWT;
+import io.gravitee.apim.gateway.tests.sdk.AbstractPolicyTest;
+import io.gravitee.apim.gateway.tests.sdk.annotations.DeployApi;
+import io.gravitee.apim.gateway.tests.sdk.annotations.GatewayTest;
+import io.gravitee.definition.model.Api;
+import io.gravitee.definition.model.Plan;
+import io.gravitee.gateway.api.service.Subscription;
+import io.gravitee.gateway.api.service.SubscriptionService;
+import io.gravitee.gateway.reactive.api.policy.SecurityToken;
+import io.gravitee.policy.jwt.configuration.JWTPolicyConfiguration;
+import io.vertx.rxjava3.core.http.HttpClient;
+import java.security.SecureRandom;
+import java.time.Instant;
+import java.util.Collections;
+import java.util.Date;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.stubbing.OngoingStubbing;
+
+/**
+ * @author GraviteeSource Team
+ */
+@GatewayTest
+@DeployApi("/apis/jwt.json")
+public class JwtPolicyV4EmulationEngineDisabledTokenTypIntegrationTest extends AbstractPolicyTest<JWTPolicy, JWTPolicyConfiguration> {
+
+    private static final String CLIENT_ID = "my-test-client-id";
+    private static final String JWT_SECRET;
+    public static final String API_ID = "my-api";
+    public static final String PLAN_ID = "plan-id";
+
+    static {
+        SecureRandom random = new SecureRandom();
+        byte[] sharedSecret = new byte[32];
+        random.nextBytes(sharedSecret);
+        JWT_SECRET = new String(sharedSecret);
+    }
+
+    @Override
+    public void configureApi(Api api) {
+        Plan jwtPlan = new Plan();
+        jwtPlan.setId(PLAN_ID);
+        jwtPlan.setApi(api.getId());
+        jwtPlan.setSecurity("JWT");
+        jwtPlan.setStatus("PUBLISHED");
+
+        JWTPolicyConfiguration configuration = new JWTPolicyConfiguration();
+        configuration.setSignature(HMAC_HS256);
+        configuration.setResolverParameter(JWT_SECRET);
+        configuration.setPublicKeyResolver(GIVEN_KEY);
+        JWTPolicyConfiguration.TokenTypValidation tokenTypValidation = new JWTPolicyConfiguration.TokenTypValidation();
+        tokenTypValidation.setEnabled(false);
+        configuration.setTokenTypValidation(tokenTypValidation);
+        try {
+            jwtPlan.setSecurityDefinition(new ObjectMapper().writeValueAsString(configuration));
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException("Failed to set JWT policy configuration", e);
+        }
+
+        api.setPlans(Collections.singletonList(jwtPlan));
+    }
+
+    @Test
+    @DisplayName("Should access API with typ JWS when token type validation is disabled")
+    void shouldAccessApiWithJwsTypWhenTokenTypValidationIsDisabled(HttpClient httpClient) throws Exception {
+        assertAccessWithToken(httpClient, getJsonWebToken("JWS"));
+    }
+
+    @Test
+    @DisplayName("Should access API with no typ header when token type validation is disabled")
+    void shouldAccessApiWithNoTypHeaderWhenTokenTypValidationIsDisabled(HttpClient httpClient) throws Exception {
+        assertAccessWithToken(httpClient, getJsonWebTokenWithoutTyp());
+    }
+
+    private void assertAccessWithToken(HttpClient httpClient, String jwtToken) throws InterruptedException {
+        wiremock.stubFor(get("/team").willReturn(ok("response from backend")));
+
+        whenSearchingSubscription().thenReturn(Optional.of(fakeSubscriptionFromCache()));
+
+        httpClient
+            .rxRequest(GET, "/test")
+            .flatMap(request -> request.putHeader("Authorization", "Bearer " + jwtToken).rxSend())
+            .flatMapPublisher(response -> {
+                assertThat(response.statusCode()).isEqualTo(200);
+                return response.toFlowable();
+            })
+            .test()
+            .await()
+            .assertComplete()
+            .assertValue(body -> {
+                assertThat(body.toString()).isEqualTo("response from backend");
+                return true;
+            })
+            .assertNoErrors();
+
+        wiremock.verify(1, getRequestedFor(urlPathEqualTo("/team")));
+    }
+
+    private Subscription fakeSubscriptionFromCache() {
+        final Subscription subscription = new Subscription();
+        subscription.setApplication("application-id");
+        subscription.setId("subscription-id");
+        subscription.setPlan(PLAN_ID);
+        return subscription;
+    }
+
+    private String getJsonWebToken(String type) throws Exception {
+        JWTClaimsSet jwtClaimsSet = new JWTClaimsSet.Builder()
+            .claim("client_id", CLIENT_ID)
+            .expirationTime(Date.from(Instant.now().plusSeconds(5000)))
+            .build();
+        SignedJWT signedJWT = new SignedJWT(
+            new JWSHeader.Builder(new JWSHeader(HMAC_HS256.getAlg())).type(new JOSEObjectType(type)).build(),
+            jwtClaimsSet
+        );
+        signedJWT.sign(new MACSigner(JWT_SECRET));
+        return signedJWT.serialize();
+    }
+
+    private String getJsonWebTokenWithoutTyp() throws Exception {
+        JWTClaimsSet jwtClaimsSet = new JWTClaimsSet.Builder()
+            .claim("client_id", CLIENT_ID)
+            .expirationTime(Date.from(Instant.now().plusSeconds(5000)))
+            .build();
+        SignedJWT signedJWT = new SignedJWT(new JWSHeader(HMAC_HS256.getAlg()), jwtClaimsSet);
+        signedJWT.sign(new MACSigner(JWT_SECRET));
+        return signedJWT.serialize();
+    }
+
+    protected OngoingStubbing<Optional<Subscription>> whenSearchingSubscription() {
+        return when(
+            getBean(SubscriptionService.class).getByApiAndSecurityToken(
+                eq(JwtPolicyV4EmulationEngineDisabledTokenTypIntegrationTest.API_ID),
+                securityTokenMatcher(),
+                eq(JwtPolicyV4EmulationEngineDisabledTokenTypIntegrationTest.PLAN_ID)
+            )
+        );
+    }
+
+    private SecurityToken securityTokenMatcher() {
+        return argThat(
+            securityToken ->
+                securityToken.getTokenType().equals(SecurityToken.TokenType.CLIENT_ID.name()) &&
+                securityToken.getTokenValue().equals(JwtPolicyV4EmulationEngineDisabledTokenTypIntegrationTest.CLIENT_ID)
+        );
+    }
+}

--- a/src/test/java/io/gravitee/policy/jwt/utils/TokenTypeVerifierFactoryTest.java
+++ b/src/test/java/io/gravitee/policy/jwt/utils/TokenTypeVerifierFactoryTest.java
@@ -15,7 +15,8 @@
  */
 package io.gravitee.policy.jwt.utils;
 
-import static org.assertj.core.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
 
 import com.nimbusds.jose.JOSEObjectType;
 import com.nimbusds.jose.proc.DefaultJOSEObjectTypeVerifier;
@@ -34,29 +35,21 @@ import org.mockito.junit.jupiter.MockitoExtension;
 class TokenTypeVerifierFactoryTest {
 
     @Test
-    void buildDefault_should_return_default_verifier() {
-        DefaultJOSEObjectTypeVerifier<SecurityContext> verifier = TokenTypeVerifierFactory.buildDefault();
-        assertThat(verifier).isNotNull();
-        assertThat(verifier.getAllowedTypes()).containsExactlyInAnyOrder(
-            JOSEObjectType.JWT,
-            new JOSEObjectType("at+jwt"),
-            new JOSEObjectType("application/at+jwt"),
-            null
-        );
-    }
-
-    @Test
-    void build_should_return_default_verifier_when_tokenTypValidation_is_null() {
+    void build_should_return_permissive_verifier_when_tokenTypValidation_is_null() {
         JOSEObjectTypeVerifier<SecurityContext> verifier = TokenTypeVerifierFactory.build(null);
-        assertThat(verifier).isInstanceOf(DefaultJOSEObjectTypeVerifier.class);
+        assertThat(verifier).isNotInstanceOf(DefaultJOSEObjectTypeVerifier.class);
+        assertAcceptsTyp(verifier, "JWS");
+        assertAcceptsMissingTyp(verifier);
     }
 
     @Test
-    void build_should_return_default_verifier_when_tokenTypValidation_is_disabled() {
+    void build_should_return_permissive_verifier_when_tokenTypValidation_is_disabled() {
         JWTPolicyConfiguration.TokenTypValidation tokenTypValidation = new JWTPolicyConfiguration.TokenTypValidation();
         tokenTypValidation.setEnabled(false);
         JOSEObjectTypeVerifier<SecurityContext> verifier = TokenTypeVerifierFactory.build(tokenTypValidation);
-        assertThat(verifier).isInstanceOf(DefaultJOSEObjectTypeVerifier.class);
+        assertThat(verifier).isNotInstanceOf(DefaultJOSEObjectTypeVerifier.class);
+        assertAcceptsTyp(verifier, "JWS");
+        assertAcceptsMissingTyp(verifier);
     }
 
     @Test
@@ -69,5 +62,13 @@ class TokenTypeVerifierFactoryTest {
 
         JOSEObjectTypeVerifier<SecurityContext> verifier = TokenTypeVerifierFactory.build(tokenTypValidation);
         assertThat(verifier).isNotInstanceOf(DefaultJOSEObjectTypeVerifier.class).isInstanceOf(JOSEObjectTypeVerifier.class);
+    }
+
+    private void assertAcceptsTyp(JOSEObjectTypeVerifier<SecurityContext> verifier, String typ) {
+        assertThatCode(() -> verifier.verify(new JOSEObjectType(typ), null)).doesNotThrowAnyException();
+    }
+
+    private void assertAcceptsMissingTyp(JOSEObjectTypeVerifier<SecurityContext> verifier) {
+        assertThatCode(() -> verifier.verify(null, null)).doesNotThrowAnyException();
     }
 }


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-13814

## Description
When Enable token type validation is turned OFF on a JWT plan, operators expect the gateway to skip typ header checks and validate only the signature and standard JWT claims.

In practice, valid tokens with typ: JWS are rejected with:

Error key: JWT_INVALID_TOKEN
Message: Unauthorized (JOSE header typ (type) JWS not allowed)

Fix:
When token type validation is null or disabled, return a permissive no-op verifier that accepts any typ value (including JWS), instead of DefaultJOSEObjectTypeVerifier.

When validation is enabled, behaviour is unchanged: buildCustom() validates against the configured expected values.

Before & After:
<img width="835" height="432" alt="image" src="https://github.com/user-attachments/assets/901bdb11-e8c9-496f-ab9b-d490429c6718" />
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `7.0.4-APIM-13814-diabled-token-validation-with-jws-fix-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/policy/gravitee-policy-jwt/7.0.4-APIM-13814-diabled-token-validation-with-jws-fix-SNAPSHOT/gravitee-policy-jwt-7.0.4-APIM-13814-diabled-token-validation-with-jws-fix-SNAPSHOT.zip)
  <!-- Version placeholder end -->
