### PR TITLE
fix: bump apim dependency to 4.12.0-milestone.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,7 @@
     </parent>
 
     <properties>
-        <gravitee-apim.version>4.12.0-SNAPSHOT</gravitee-apim.version>
+        <gravitee-apim.version>4.12.0-milestone.1</gravitee-apim.version>
 
         <sshj.version>0.40.0</sshj.version>
         <maven-plugin-properties.version>1.3.0</maven-plugin-properties.version>


### PR DESCRIPTION
## Issue

N/A — no associated issue

## Description

Bump the APIM dependency to the released `4.12.0-milestone.1` so this plugin no longer depends on a SNAPSHOT and can be released to Maven Central.

## Additional context

<!-- N/A -->
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `8.0.0-bump-apim-version-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/policy/gravitee-policy-jwt/8.0.0-bump-apim-version-SNAPSHOT/gravitee-policy-jwt-8.0.0-bump-apim-version-SNAPSHOT.zip)
  <!-- Version placeholder end -->
